### PR TITLE
Exporting all AutoSkill configs at once

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -2,6 +2,22 @@
   <code_scheme name="Project" version="173">
     <option name="RIGHT_MARGIN" value="150" />
     <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value>
+          <package name="java.util" alias="false" withSubpackages="false" />
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+          <package name="io.ktor" alias="false" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
+        </value>
+      </option>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="XML">

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/ui/prefs/AutoSkillItemSettingsFragment.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/ui/prefs/AutoSkillItemSettingsFragment.kt
@@ -29,9 +29,12 @@ import com.mathewsachin.fategrandautomata.util.appComponent
 import com.mathewsachin.fategrandautomata.util.preferredSupportOnCreate
 import com.mathewsachin.fategrandautomata.util.preferredSupportOnResume
 import kotlinx.coroutines.launch
+import mu.KotlinLogging
 import java.util.*
 import javax.inject.Inject
 import com.mathewsachin.fategrandautomata.prefs.R.string as prefKeys
+
+private val logger = KotlinLogging.logger {}
 
 class AutoSkillItemSettingsFragment : PreferenceFragmentCompat() {
     @Inject
@@ -53,12 +56,18 @@ class AutoSkillItemSettingsFragment : PreferenceFragmentCompat() {
 
     val autoSkillExport = registerForActivityResult(ActivityResultContracts.CreateDocument()) { uri ->
         if (uri != null) {
-            val values = preferences.forAutoSkillConfig(args.key).export()
-            val gson = Gson()
-            val json = gson.toJson(values)
+            try {
+                val values = preferences.forAutoSkillConfig(args.key).export()
+                val gson = Gson()
+                val json = gson.toJson(values)
 
-            requireContext().contentResolver.openOutputStream(uri)?.use { outStream ->
-                outStream.writer().use { it.write(json) }
+                requireContext().contentResolver.openOutputStream(uri)?.use { outStream ->
+                    outStream.writer().use { it.write(json) }
+                }
+            } catch (e: Exception) {
+                logger.error("Failed to export", e)
+
+                Toast.makeText(context, "Failed to Export", Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/app/src/main/res/menu/autoskill_list_menu.xml
+++ b/app/src/main/res/menu/autoskill_list_menu.xml
@@ -6,4 +6,9 @@
         android:icon="@drawable/ic_zip"
         android:title="Import"
         app:showAsAction="never" />
+    <item
+        android:id="@+id/action_auto_skill_export_all"
+        android:icon="@drawable/ic_zip"
+        android:title="Export all"
+        app:showAsAction="never" />
 </menu>


### PR DESCRIPTION
fixes #276 

Option is present on AutoSkill List screen. You'll be prompted to choose a folder.
All configs will be exported to that folder. If a config file is already present in that folder, a new file name with a number appended is used (default behaviour of Android).