### PR TITLE
Restore root functionality for all Android versions

### DIFF
--- a/app/src/main/java/com/mathewsachin/fategrandautomata/accessibility/ScriptRunnerService.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/accessibility/ScriptRunnerService.kt
@@ -123,8 +123,7 @@ class ScriptRunnerService : AccessibilityService() {
         Instance = null
     }
 
-    val wantsMediaProjectionToken: Boolean
-        get() = !(RootScreenshotService.canUseRootForScreenshots() && prefs.useRootForScreenshots)
+    val wantsMediaProjectionToken: Boolean get() = !prefs.useRootForScreenshots
 
     var serviceState: ServiceState = ServiceState.Stopped
         private set

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/root/RootScreenshotService.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/root/RootScreenshotService.kt
@@ -21,47 +21,37 @@ class RootScreenshotService(
     val storageProvider: StorageProvider,
     val platformImpl: IPlatformImpl
 ) : IScreenshotService, IColorScreenshotProvider {
-    companion object {
-        fun canUseRootForScreenshots() =
-            Build.VERSION.SDK_INT < Build.VERSION_CODES.P
-    }
-
+    private var reader: DataInputStream = SuperUser.inStream
     private var buffer: ByteArray? = null
-    private val imgPath = storageProvider.rootScreenshotFile
 
     private var rootLoadMat: Mat? = null
     private val rootConvertMat = Mat()
     private val pattern = DroidCvPattern(rootConvertMat, false)
 
     private fun screenshotIntoBuffer() {
-        SuperUser.sendCommand("/system/bin/screencap $imgPath")
+        SuperUser.writeLine("/system/bin/screencap")
 
-        imgPath.inputStream().use {
-            DataInputStream(it).use { reader ->
-                val w = reader.readIntLE()
-                val h = reader.readIntLE()
-                val format = reader.readIntLE()
+        val w = reader.readIntLE()
+        val h = reader.readIntLE()
+        val format = reader.readIntLE()
 
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    reader.readIntLE()
-                }
-
-                if (buffer == null) {
-                    // If format is not RGBA, notify
-                    if (format != 1) {
-                        platformImpl.toast("Unexpected raw image format: $format")
-                    }
-
-                    Timber.debug { "${w}x${h} format=$format" }
-
-                    buffer = ByteArray(w * h * 4)
-                    rootLoadMat = Mat(h, w, CvType.CV_8UC4)
-                }
-
-                buffer?.let { b -> reader.read(b, 0, b.size) }
-            }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            reader.readIntLE()
         }
 
+        if (buffer == null) {
+            // If format is not RGBA, notify
+            if (format != 1) {
+                platformImpl.toast("Unexpected raw image format: $format")
+            }
+
+            Timber.debug { "${w}x${h} format=$format" }
+
+            buffer = ByteArray(w * h * 4)
+            rootLoadMat = Mat(h, w, CvType.CV_8UC4)
+        }
+
+        buffer?.let { b -> reader.read(b, 0, b.size) }
         rootLoadMat?.put(0, 0, buffer)
     }
 

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/root/RootScreenshotService.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/root/RootScreenshotService.kt
@@ -51,7 +51,9 @@ class RootScreenshotService(
             rootLoadMat = Mat(h, w, CvType.CV_8UC4)
         }
 
-        buffer?.let { b -> reader.read(b, 0, b.size) }
+        // "readFully" will wait for the entire data (b.size) to be available in the input stream,
+        // however long it takes (in actuality, it just takes a few milliseconds).
+        buffer?.let { b -> reader.readFully(b, 0, b.size) }
         rootLoadMat?.put(0, 0, buffer)
     }
 

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/root/SuperUser.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/root/SuperUser.kt
@@ -1,5 +1,6 @@
 package com.mathewsachin.fategrandautomata.root
 
+import java.io.DataInputStream
 import java.io.DataOutputStream
 
 /**
@@ -8,6 +9,7 @@ import java.io.DataOutputStream
 class SuperUser : AutoCloseable {
     var superUser: Process
     var outStream: DataOutputStream
+    var inStream: DataInputStream
 
     /**
      * Requests superuser rights and checks if the attempt was successful.
@@ -18,6 +20,7 @@ class SuperUser : AutoCloseable {
         try {
             superUser = Runtime.getRuntime().exec("su", null, null)
             outStream = DataOutputStream(superUser.outputStream)
+            inStream = DataInputStream(superUser.inputStream)
 
             // We can check if we got root by sending 'id' to the su process which returns current user's id.
             // The response should contain 'uid=0', where 0 is the id of root user.
@@ -47,7 +50,7 @@ class SuperUser : AutoCloseable {
     /**
      * Writes a line to the shell.
      */
-    private fun writeLine(Line: String) {
+    fun writeLine(Line: String) {
         outStream.writeBytes("${Line}\n")
         outStream.flush()
     }

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/root/SuperUser.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/root/SuperUser.kt
@@ -56,15 +56,6 @@ class SuperUser : AutoCloseable {
     }
 
     /**
-     * Executes a shell command and waits until it's finished.
-     */
-    fun sendCommand(Command: String) {
-        writeLine(Command)
-
-        waitForCommand()
-    }
-
-    /**
      * Exits the shell, which also terminates the superuser session.
      */
     override fun close() {

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/root/SuperUser.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/root/SuperUser.kt
@@ -38,6 +38,14 @@ class SuperUser : AutoCloseable {
     }
 
     /**
+     * Writes a line to the shell.
+     */
+    fun writeLine(Line: String) {
+        outStream.writeBytes("${Line}\n")
+        outStream.flush()
+    }
+
+    /**
      * Waits until the previous command has finished.
      */
     private fun waitForCommand() {
@@ -45,14 +53,6 @@ class SuperUser : AutoCloseable {
         writeLine("echo -n 0")
 
         superUser.inputStream.read()
-    }
-
-    /**
-     * Writes a line to the shell.
-     */
-    fun writeLine(Line: String) {
-        outStream.writeBytes("${Line}\n")
-        outStream.flush()
     }
 
     /**

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/ui/prefs/MoreSettingsFragment.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/ui/prefs/MoreSettingsFragment.kt
@@ -57,15 +57,6 @@ class MoreSettingsFragment : PreferenceFragmentCompat() {
 
             it.summary = storageProvider.rootDirName
         }
-
-        findPreference<SwitchPreferenceCompat>(getString(R.string.pref_use_root_screenshot))?.let {
-            val canUseRoot = RootScreenshotService.canUseRootForScreenshots()
-            it.isEnabled = canUseRoot
-
-            if (!canUseRoot) {
-                it.isChecked = false
-            }
-        }
     }
 
     private val pickDir = registerForActivityResult(ActivityResultContracts.OpenDocumentTree()) { dirUrl ->

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/util/StorageProvider.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/util/StorageProvider.kt
@@ -45,9 +45,6 @@ class StorageProvider @Inject constructor(
     val rootDirName
         get() = dirRoot?.name
 
-    val rootScreenshotFile
-        get() = File(context.getExternalFilesDir(null), "sshot.raw")
-
     private val recordingFile
         get() = dirRoot.getOrCreateFile("record.mp4")
 


### PR DESCRIPTION
Okay, I'm a complete noob when it comes to Kotlin/Android development, so I apologize in advance for code smells, if any.

I hugely prefer root mode over media projection, so I wanted to restore this feature after it has been pretty much killed by 92b9ae71. After a bit of searching, I found that the `screencap` command prints directly to `stdout` if you omit the file parameter (see [here](https://stackoverflow.com/questions/51782364/screencap-directly-tobytearray-skipping-saving-to-memory/51782529) and [here](https://github.com/aosp-mirror/platform_frameworks_base/blob/master/cmds/screencap/screencap.cpp)), so that's exactly what I did. I had to tweak some stuff in `SuperUser` to make `su`'s input stream available to `RootScreenshotService`, so the latter could consume it directly. I feel that those two files are more coupled together now, so I would really appreciate some input with this.

Despite my concerns with the code quality, it's working great, as you can see in the video attached. 😄 


https://user-images.githubusercontent.com/4316326/103143482-b0ad2080-46f5-11eb-8b6f-a20a2af02468.mp4