### PR TITLE
Wait AP Regen Fix

### DIFF
--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/entrypoints/AutoBattle.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/entrypoints/AutoBattle.kt
@@ -461,7 +461,7 @@ open class AutoBattle @Inject constructor(
             3.seconds.wait()
         } else if (waitAPRegenPrefs) {
             Location(1300, 1240).click()
-            for (i in waitAPRegenMinutePrefs..1) {
+            for (i in waitAPRegenMinutePrefs downTo 1) {
                 toast(messages.waitAPToast(i))
                 60.seconds.wait()
             }


### PR DESCRIPTION
Sorry for bothering. Last night thought `..` works for decreasing for loops without checking whether it actually works, and now FGA skips the waiting time and keeps checking nonstop. [Stackoverflow](https://stackoverflow.com/questions/9562605/in-kotlin-can-i-create-a-range-that-counts-backwards) says I should have used `downTo` instead of `..` in a decreasing variable situation so I made a simple fix.