### PR TITLE
TW Translation for support friend name

### DIFF
--- a/app/src/main/res/values-b+zh+TW/localized.xml
+++ b/app/src/main/res/values-b+zh+TW/localized.xml
@@ -126,7 +126,6 @@
     <string name="p_battle_config_support_friends_only">只選擇好友從者</string>
     <string name="p_battle_config_support_friend_name_hint">請使用「支援圖片截取器」腳本加入好友名稱的圖片</string>
 
-
     <string name="p_max_skill_1">一技滿等</string>
     <string name="p_max_skill_2">二技滿等</string>
     <string name="p_max_skill_3">三技滿等</string>

--- a/app/src/main/res/values-b+zh+TW/localized.xml
+++ b/app/src/main/res/values-b+zh+TW/localized.xml
@@ -124,6 +124,8 @@
     <string name="p_battle_config_support_mlb">滿破禮裝</string>
     <string name="p_battle_config_support_friend_names">好友名稱</string>
     <string name="p_battle_config_support_friends_only">只選擇好友從者</string>
+    <string name="p_battle_config_support_friend_name_hint">請使用「支援圖片截取器」腳本加入好友名稱的圖片</string>
+
 
     <string name="p_max_skill_1">一技滿等</string>
     <string name="p_max_skill_2">二技滿等</string>


### PR DESCRIPTION
Noticed an update on the translatable support_friend_name_hint text, so here's the TW translation.

Original text is **Friend name images can be added using \'Support Image Maker\' script**, translated/paraphrased to **Please use 'Support Image Maker" script to add images of friend name**.