### PR TITLE
Auto-decrement for Runs and Materials

### DIFF
--- a/app/src/main/java/com/mathewsachin/fategrandautomata/ui/prefs/MainSettingsViewModel.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/ui/prefs/MainSettingsViewModel.kt
@@ -41,9 +41,21 @@ class MainSettingsViewModel @ViewModelInject constructor(
         .asFlow()
         .asLiveData()
 
+    val shouldLimitRuns = prefsCore
+        .refill
+        .shouldLimitRuns
+        .asFlow()
+        .asLiveData()
+
     val limitRuns = prefsCore
         .refill
         .limitRuns
+        .asFlow()
+        .asLiveData()
+
+    val shouldLimitMats = prefsCore
+        .refill
+        .shouldLimitMats
         .asFlow()
         .asLiveData()
 

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/ui/prefs/MainSettingsViewModel.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/ui/prefs/MainSettingsViewModel.kt
@@ -41,6 +41,18 @@ class MainSettingsViewModel @ViewModelInject constructor(
         .asFlow()
         .asLiveData()
 
+    val limitRuns = prefsCore
+        .refill
+        .limitRuns
+        .asFlow()
+        .asLiveData()
+
+    val limitMats = prefsCore
+        .refill
+        .limitMats
+        .asFlow()
+        .asLiveData()
+
     private val refillResourcesFlow = prefsCore
         .refill
         .resources

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/ui/prefs/RefillSettingsFragment.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/ui/prefs/RefillSettingsFragment.kt
@@ -38,6 +38,18 @@ class RefillSettingsFragment : PreferenceFragmentCompat() {
             }
         }
 
+        findPreference<EditTextPreference>(getString(R.string.pref_limit_runs))?.let {
+            vm.limitRuns.observe(viewLifecycleOwner) { runs ->
+                it.text = runs.toString()
+            }
+        }
+
+        findPreference<EditTextPreference>(getString(R.string.pref_limit_mats))?.let {
+            vm.limitMats.observe(viewLifecycleOwner) { mats ->
+                it.text = mats.toString()
+            }
+        }
+
         findPreference<MultiSelectListPreference>(getString(R.string.pref_refill_resource))?.let {
             vm.refillResources.observe(viewLifecycleOwner) { refillResourcesMsg ->
                 it.summary = refillResourcesMsg

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/ui/prefs/RefillSettingsFragment.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/ui/prefs/RefillSettingsFragment.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.preference.EditTextPreference
 import androidx.preference.MultiSelectListPreference
 import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.SwitchPreferenceCompat
 import com.mathewsachin.fategrandautomata.R
 import com.mathewsachin.fategrandautomata.scripts.enums.RefillResourceEnum
 import com.mathewsachin.fategrandautomata.util.initWith
@@ -32,9 +33,16 @@ class RefillSettingsFragment : PreferenceFragmentCompat() {
 
         val vm: MainSettingsViewModel by activityViewModels()
 
+        // These don't update automatically
         findPreference<EditTextPreference>(getString(R.string.pref_refill_repetitions))?.let {
             vm.refillRepetitions.observe(viewLifecycleOwner) { repetitions ->
                 it.text = repetitions.toString()
+            }
+        }
+
+        findPreference<SwitchPreferenceCompat>(getString(R.string.pref_should_limit_runs))?.let {
+            vm.shouldLimitRuns.observe(viewLifecycleOwner) { should ->
+                it.isChecked = should
             }
         }
 
@@ -44,12 +52,19 @@ class RefillSettingsFragment : PreferenceFragmentCompat() {
             }
         }
 
+        findPreference<SwitchPreferenceCompat>(getString(R.string.pref_should_limit_mats))?.let {
+            vm.shouldLimitMats.observe(viewLifecycleOwner) { should ->
+                it.isChecked = should
+            }
+        }
+
         findPreference<EditTextPreference>(getString(R.string.pref_limit_mats))?.let {
             vm.limitMats.observe(viewLifecycleOwner) { mats ->
                 it.text = mats.toString()
             }
         }
 
+        // Refill resources shown with priority
         findPreference<MultiSelectListPreference>(getString(R.string.pref_refill_resource))?.let {
             vm.refillResources.observe(viewLifecycleOwner) { refillResourcesMsg ->
                 it.summary = refillResourcesMsg

--- a/app/src/main/res/xml/refill_preferences.xml
+++ b/app/src/main/res/xml/refill_preferences.xml
@@ -49,6 +49,13 @@
             app:key="@string/pref_limit_runs"
             app:title="@string/p_runs"
             app:useSimpleSummaryProvider="true" />
+
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:icon="@drawable/ic_minus"
+            app:key="@string/pref_limit_runs_decrement"
+            app:dependency="@string/pref_should_limit_runs"
+            app:title="@string/p_auto_decrement" />
     </PreferenceCategory>
 
     <PreferenceCategory
@@ -67,5 +74,12 @@
             app:key="@string/pref_limit_mats"
             app:title="@string/p_mat_limit_count"
             app:useSimpleSummaryProvider="true" />
+
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:icon="@drawable/ic_minus"
+            app:key="@string/pref_limit_mats_decrement"
+            app:dependency="@string/pref_should_limit_mats"
+            app:title="@string/p_auto_decrement" />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/RefillPreferences.kt
+++ b/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/RefillPreferences.kt
@@ -19,13 +19,13 @@ internal class RefillPreferences(val prefs: RefillPrefsCore) :
 
     override val autoDecrement by prefs.autoDecrement
 
-    override val shouldLimitRuns by prefs.shouldLimitRuns
+    override var shouldLimitRuns by prefs.shouldLimitRuns
 
     override var limitRuns by prefs.limitRuns
 
     override val autoDecrementRuns by prefs.autoDecrementRuns
 
-    override val shouldLimitMats by prefs.shouldLimitMats
+    override var shouldLimitMats by prefs.shouldLimitMats
 
     override var limitMats by prefs.limitMats
 

--- a/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/RefillPreferences.kt
+++ b/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/RefillPreferences.kt
@@ -21,9 +21,13 @@ internal class RefillPreferences(val prefs: RefillPrefsCore) :
 
     override val shouldLimitRuns by prefs.shouldLimitRuns
 
-    override val limitRuns by prefs.limitRuns
+    override var limitRuns by prefs.limitRuns
+
+    override val autoDecrementRuns by prefs.autoDecrementRuns
 
     override val shouldLimitMats by prefs.shouldLimitMats
 
-    override val limitMats by prefs.limitMats
+    override var limitMats by prefs.limitMats
+
+    override val autoDecrementMats by prefs.autoDecrementMats
 }

--- a/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/core/RefillPrefsCore.kt
+++ b/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/core/RefillPrefsCore.kt
@@ -15,7 +15,11 @@ class RefillPrefsCore(maker: PrefMaker) {
 
     val limitRuns = maker.stringAsInt(R.string.pref_limit_runs, 1)
 
+    val autoDecrementRuns = maker.bool(R.string.pref_limit_runs_decrement)
+
     val shouldLimitMats = maker.bool(R.string.pref_should_limit_mats)
 
     val limitMats = maker.stringAsInt(R.string.pref_limit_mats, 1)
+
+    val autoDecrementMats = maker.bool(R.string.pref_limit_mats_decrement)
 }

--- a/prefs/src/main/res/values/preferences.xml
+++ b/prefs/src/main/res/values/preferences.xml
@@ -56,8 +56,10 @@
     <string name="pref_screenshot_drops">screenshot_drops</string>
     <string name="pref_should_limit_runs">should_limit_runs</string>
     <string name="pref_limit_runs">limit_runs</string>
+    <string name="pref_limit_runs_decrement">limit_runs_decrement</string>
     <string name="pref_should_limit_mats">should_limit_mats</string>
     <string name="pref_limit_mats">limit_mats</string>
+    <string name="pref_limit_mats_decrement">limit_mats_decrement</string>
 
     <string name="pref_ignore_notch">ignore_notch</string>
     <string name="pref_use_root_screenshot">use_root_screenshot</string>

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/entrypoints/AutoBattle.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/entrypoints/AutoBattle.kt
@@ -70,19 +70,31 @@ open class AutoBattle @Inject constructor(
         } finally {
             val refill = prefs.refill
 
+            // Auto-decrement apples
             if (refill.autoDecrement) {
                 refill.repetitions -= stonesUsed
             }
 
+            // Auto-decrement runs
             if (refill.shouldLimitRuns && refill.autoDecrementRuns) {
                 refill.limitRuns -= battle.state.runs
+
+                // Turn off run limit when done
+                if (refill.limitRuns <= 0) {
+                    refill.limitRuns = 1
+                    refill.shouldLimitRuns = false
+                }
             }
 
+            // Auto-decrement materials
             if (refill.shouldLimitMats && refill.autoDecrementMats) {
-                val totalMats = matsGot.values.sum()
+                refill.limitMats -= matsGot.values.sum()
 
-                refill.limitMats = (refill.limitMats - totalMats)
-                    .coerceAtLeast(0)
+                // Turn off limit by materials when done
+                if (refill.limitMats <= 0) {
+                    refill.limitMats = 1
+                    refill.shouldLimitMats = false
+                }
             }
         }
     }

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/entrypoints/AutoBattle.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/entrypoints/AutoBattle.kt
@@ -68,8 +68,21 @@ open class AutoBattle @Inject constructor(
         } catch (e: Exception) {
             throw Exception(makeExitMessage("${messages.unexpectedError}: ${e.message}"), e)
         } finally {
-            if (prefs.refill.autoDecrement) {
-                prefs.refill.repetitions -= stonesUsed
+            val refill = prefs.refill
+
+            if (refill.autoDecrement) {
+                refill.repetitions -= stonesUsed
+            }
+
+            if (refill.shouldLimitRuns && refill.autoDecrementRuns) {
+                refill.limitRuns -= battle.state.runs
+            }
+
+            if (refill.shouldLimitMats && refill.autoDecrementMats) {
+                val totalMats = matsGot.values.sum()
+
+                refill.limitMats = (refill.limitMats - totalMats)
+                    .coerceAtLeast(0)
             }
         }
     }

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/Battle.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/Battle.kt
@@ -28,10 +28,10 @@ class Battle(fgAutomataApi: IFgoAutomataApi) : IFgoAutomataApi by fgAutomataApi 
         // This can happen due to lags introduced during some events
         if (state.stage != -1) {
             state.nextRun()
+        }
 
-            if (prefs.refill.shouldLimitRuns && state.runs >= prefs.refill.limitRuns) {
-                throw ScriptExitException(messages.timesRan(state.runs))
-            }
+        if (prefs.refill.shouldLimitRuns && state.runs >= prefs.refill.limitRuns) {
+            throw ScriptExitException(messages.timesRan(state.runs))
         }
     }
 

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/prefs/IRefillPreferences.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/prefs/IRefillPreferences.kt
@@ -8,11 +8,11 @@ interface IRefillPreferences {
     val resources: List<RefillResourceEnum>
     val autoDecrement: Boolean
 
-    val shouldLimitRuns: Boolean
+    var shouldLimitRuns: Boolean
     var limitRuns: Int
     val autoDecrementRuns: Boolean
 
-    val shouldLimitMats: Boolean
+    var shouldLimitMats: Boolean
     var limitMats: Int
     val autoDecrementMats: Boolean
 }

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/prefs/IRefillPreferences.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/prefs/IRefillPreferences.kt
@@ -9,8 +9,10 @@ interface IRefillPreferences {
     val autoDecrement: Boolean
 
     val shouldLimitRuns: Boolean
-    val limitRuns: Int
+    var limitRuns: Int
+    val autoDecrementRuns: Boolean
 
     val shouldLimitMats: Boolean
-    val limitMats: Int
+    var limitMats: Int
+    val autoDecrementMats: Boolean
 }


### PR DESCRIPTION
Auto-decrement Runs/Materials turns OFF limit Runs/Materials when the count reaches 0 and resets the count to 1.