### PR TITLE
Repeat Battle in TW

### DIFF
--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/entrypoints/AutoBattle.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/entrypoints/AutoBattle.kt
@@ -336,11 +336,7 @@ open class AutoBattle @Inject constructor(
         storageProvider.dropScreenshot(drops)
     }
 
-    private fun isRepeatScreen() =
-        // Not yet on TW
-        if (prefs.gameServer != GameServerEnum.Tw) {
-            images.confirm in game.continueRegion
-        } else false
+    private fun isRepeatScreen() = images.confirm in game.continueRegion;
 
     private fun repeatQuest() {
         // Needed to show we don't need to enter the "StartQuest" function


### PR DESCRIPTION
As discussed in #715, here's the fix to bring TW server up to date with the rest of the world for the 4th anniversary update that brings repeating battles to FGO.

I will remove the check that excludes TW in the isRepeatScreen check and add corresponding image to match.