### PR TITLE
Lottery script can start receiving embers when Present box is full

### DIFF
--- a/app/src/main/java/com/mathewsachin/fategrandautomata/ui/launcher/GiftBoxLauncher.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/ui/launcher/GiftBoxLauncher.kt
@@ -2,15 +2,12 @@ package com.mathewsachin.fategrandautomata.ui.launcher
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -18,6 +15,28 @@ import androidx.compose.ui.unit.dp
 import com.mathewsachin.fategrandautomata.R
 import com.mathewsachin.fategrandautomata.scripts.prefs.IPreferences
 import com.mathewsachin.fategrandautomata.ui.Stepper
+
+@Composable
+fun ColumnScope.GiftBoxLauncherContent(
+    maxGoldEmberStackSize: Int,
+    changeMaxEmberStackSize: (Int) -> Unit
+) {
+    Text(
+        stringResource(R.string.p_max_gold_ember_set_size),
+        style = MaterialTheme.typography.body2,
+        color = MaterialTheme.colors.secondary
+    )
+
+    Box(
+        modifier = Modifier.align(Alignment.End)
+    ) {
+        Stepper(
+            value = maxGoldEmberStackSize,
+            onValueChange = changeMaxEmberStackSize,
+            valueRange = 0..4
+        )
+    }
+}
 
 @Composable
 fun giftBoxLauncher(
@@ -42,21 +61,10 @@ fun giftBoxLauncher(
                 .padding(bottom = 16.dp)
         )
 
-        Text(
-            stringResource(R.string.p_max_gold_ember_set_size),
-            style = MaterialTheme.typography.body2,
-            color = MaterialTheme.colors.secondary
+        GiftBoxLauncherContent(
+            maxGoldEmberStackSize = maxGoldEmberStackSize,
+            changeMaxEmberStackSize = { maxGoldEmberStackSize = it }
         )
-
-        Box(
-            modifier = Modifier.align(Alignment.End)
-        ) {
-            Stepper(
-                value = maxGoldEmberStackSize,
-                onValueChange = { maxGoldEmberStackSize = it },
-                valueRange = 0..4
-            )
-        }
     }
 
     return ScriptLauncherResponseBuilder(

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/ui/launcher/LotteryLauncher.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/ui/launcher/LotteryLauncher.kt
@@ -6,11 +6,7 @@ import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Switch
 import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -24,6 +20,8 @@ fun lotteryLauncher(
     modifier: Modifier = Modifier
 ): ScriptLauncherResponseBuilder {
     var preventReset by remember { mutableStateOf(prefs.preventLotteryBoxReset) }
+    var receiveEmbers by remember { mutableStateOf(prefs.receiveEmbersWhenGiftBoxFull) }
+    var maxGoldEmberStackSize by remember { mutableStateOf(prefs.maxGoldEmberSetSize) }
 
     Column(
         modifier = modifier
@@ -59,12 +57,42 @@ fun lotteryLauncher(
                 onCheckedChange = { preventReset = it }
             )
         }
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 5.dp)
+                .clickable { receiveEmbers = !receiveEmbers }
+        ) {
+            Text(
+                "Receive embers",
+                style = MaterialTheme.typography.body2,
+                color = MaterialTheme.colors.secondary
+            )
+
+            Switch(
+                checked = receiveEmbers,
+                onCheckedChange = { receiveEmbers = it }
+            )
+        }
+
+        if (receiveEmbers) {
+            GiftBoxLauncherContent(
+                maxGoldEmberStackSize = maxGoldEmberStackSize,
+                changeMaxEmberStackSize = { maxGoldEmberStackSize = it }
+            )
+        }
     }
 
     return ScriptLauncherResponseBuilder(
         canBuild = { true },
         build = {
-            ScriptLauncherResponse.Lottery(preventReset)
+            ScriptLauncherResponse.Lottery(
+                preventReset,
+                if (receiveEmbers) ScriptLauncherResponse.GiftBox(maxGoldEmberStackSize) else null
+            )
         }
     )
 }

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/ui/launcher/ScriptLauncherResponse.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/ui/launcher/ScriptLauncherResponse.kt
@@ -6,7 +6,10 @@ import com.mathewsachin.fategrandautomata.scripts.prefs.IBattleConfig
 sealed class ScriptLauncherResponse {
     object Cancel: ScriptLauncherResponse()
     data class FP(val limit: Int?): ScriptLauncherResponse()
-    data class Lottery(val preventBoxReset: Boolean): ScriptLauncherResponse()
+    data class Lottery(
+        val preventBoxReset: Boolean,
+        val giftBox: GiftBox?
+    ): ScriptLauncherResponse()
     data class GiftBox(val maxGoldEmberStackSize: Int): ScriptLauncherResponse()
     data class CEBomb(val targetRarity: Int): ScriptLauncherResponse()
     object SupportImageMaker: ScriptLauncherResponse()

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/util/ScriptManager.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/util/ScriptManager.kt
@@ -315,6 +315,10 @@ class ScriptManager @Inject constructor(
         }
     }
 
+    private fun handleGiftBoxResponse(resp: ScriptLauncherResponse.GiftBox) {
+        preferences.maxGoldEmberSetSize = resp.maxGoldEmberStackSize
+    }
+
     private fun onScriptLauncherResponse(resp: ScriptLauncherResponse, entryPointRunner: () -> Unit) {
         userInterface.isPlayButtonEnabled = true
 
@@ -328,11 +332,15 @@ class ScriptManager @Inject constructor(
             }
             is ScriptLauncherResponse.Lottery -> {
                 preferences.preventLotteryBoxReset = resp.preventBoxReset
+                val giftBoxResp = resp.giftBox
+                preferences.receiveEmbersWhenGiftBoxFull = giftBoxResp != null
+
+                giftBoxResp?.let { handleGiftBoxResponse(it) }
 
                 ScriptModeEnum.Lottery
             }
             is ScriptLauncherResponse.GiftBox -> {
-                preferences.maxGoldEmberSetSize = resp.maxGoldEmberStackSize
+                handleGiftBoxResponse(resp)
 
                 ScriptModeEnum.PresentBox
             }

--- a/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/Preferences.kt
+++ b/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/Preferences.kt
@@ -88,6 +88,8 @@ class PreferencesImpl @Inject constructor(
 
     override var preventLotteryBoxReset by prefs.preventLotteryBoxReset
 
+    override var receiveEmbersWhenGiftBoxFull by prefs.receiveEmbersWhenGiftBoxFull
+
     private val autoSkillMap = mutableMapOf<String, IBattleConfig>()
 
     override fun forBattleConfig(id: String): IBattleConfig =

--- a/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/core/PrefsCore.kt
+++ b/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/core/PrefsCore.kt
@@ -1,7 +1,6 @@
 package com.mathewsachin.fategrandautomata.prefs.core
 
 import android.content.Context
-import com.mathewsachin.fategrandautomata.scripts.entrypoints.AutoCEBomb
 import com.mathewsachin.fategrandautomata.scripts.enums.ScriptModeEnum
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -51,6 +50,7 @@ class PrefsCore @Inject constructor(
     val shouldLimitFP = maker.bool("should_fp_limit")
     val limitFP = maker.int("fp_limit", 1)
     val preventLotteryBoxReset = maker.bool("prevent_lottery_reset")
+    val receiveEmbersWhenGiftBoxFull = maker.bool("receive_embers_when_gift_box_full")
 
     val supportSwipesPerUpdate = maker.int("support_swipes_per_update_x", 10)
     val supportMaxUpdates = maker.int("support_max_updates_x", 5)

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/entrypoints/AutoGiftBox.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/entrypoints/AutoGiftBox.kt
@@ -50,7 +50,7 @@ class AutoGiftBox @Inject constructor(
             }
             else break
 
-            if (!receiveEnabledRegion.exists(receiveEnabledPattern)) break
+            if (receiveEnabledPattern !in receiveEnabledRegion) break
         }
 
         throw ExitException(totalReceived)

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/entrypoints/AutoGiftBox.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/entrypoints/AutoGiftBox.kt
@@ -3,6 +3,8 @@ package com.mathewsachin.fategrandautomata.scripts.entrypoints
 import com.mathewsachin.fategrandautomata.scripts.IFgoAutomataApi
 import com.mathewsachin.fategrandautomata.scripts.Images
 import com.mathewsachin.fategrandautomata.scripts.enums.GameServerEnum
+import com.mathewsachin.fategrandautomata.scripts.modules.needsToRetry
+import com.mathewsachin.fategrandautomata.scripts.modules.retry
 import com.mathewsachin.libautomata.EntryPoint
 import com.mathewsachin.libautomata.ExitManager
 import com.mathewsachin.libautomata.Location
@@ -31,18 +33,24 @@ class AutoGiftBox @Inject constructor(
         val checkRegion = Region(xpOffsetX + 1320, 350, 140, 1500)
         val scrollEndRegion = Region(100 + checkRegion.X, 1421, 320, 19)
         val receiveSelectedClick = Location(1890 + xpOffsetX, 750)
+        val receiveEnabledRegion = Region(1755 + xpOffsetX, 410, 290, 60)
 
         while (true) {
+            val receiveEnabledPattern = receiveEnabledRegion.getPattern()
             val picked = iteration(checkRegion, scrollEndRegion)
             totalReceived += picked
 
             if (picked > 0) {
                 receiveSelectedClick.click()
+                while (true) {
+                    Duration.seconds(2).wait()
+                    if (needsToRetry()) retry() else break
+                }
+                receiveSelectedClick.click()
             }
             else break
 
-            // TODO: Runs only once right now
-            break
+            if (!receiveEnabledRegion.exists(receiveEnabledPattern)) break
         }
 
         throw ExitException(totalReceived)

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/entrypoints/AutoLottery.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/entrypoints/AutoLottery.kt
@@ -52,6 +52,7 @@ class AutoLottery @Inject constructor(
 
             moveToPresentBox?.Region?.click()
 
+            Duration.seconds(1).wait()
             giftBox.script()
         }
 

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/prefs/IPreferences.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/prefs/IPreferences.kt
@@ -29,6 +29,7 @@ interface IPreferences {
     var shouldLimitFP: Boolean
     var limitFP: Int
     var preventLotteryBoxReset: Boolean
+    var receiveEmbersWhenGiftBoxFull: Boolean
 
     val stageCounterSimilarity: Double
     val waitBeforeTurn: Duration


### PR DESCRIPTION
When starting the Lottery script, there is an option to receive embers. You can also configure the gift box script in place.
GiftBox script now continues to receive embers multiple times unless inventory full.
If within a 2s period a connection failure happens, it can retry. If accepting embers takes more than 2s, the script will stop.
This script needs a decent device and a decent internet connection for proper functionality.