### PR TITLE
Fix incorrect debug mode rectangles for JP

### DIFF
--- a/app/src/main/java/com/mathewsachin/fategrandautomata/accessibility/ScriptRunnerUserInterface.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/accessibility/ScriptRunnerUserInterface.kt
@@ -94,6 +94,9 @@ class ScriptRunnerUserInterface @Inject constructor(
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE
         width = WindowManager.LayoutParams.MATCH_PARENT
         height = WindowManager.LayoutParams.MATCH_PARENT
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+        }
     }
 
     init {

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/util/AndroidImpl.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/util/AndroidImpl.kt
@@ -35,13 +35,10 @@ class AndroidImpl @Inject constructor(
     override fun getResizableBlankPattern(): IPattern = DroidCvPattern()
 
     override fun highlight(region: Region, duration: Duration, success: Boolean) {
-        // We can't draw over the notch area
-        val drawRegion = region - cutoutManager.getCutoutAppliedRegion().location
-
         GlobalScope.launch {
-            highlightManager.add(drawRegion, success)
+            highlightManager.add(region, success)
             delay(duration.inWholeMilliseconds)
-            highlightManager.remove(drawRegion)
+            highlightManager.remove(region)
         }
     }
 }


### PR DESCRIPTION
Fixes #809

I also temporarily enabled drawing in the notch area for the play button, but on my device that's right on top of the camera, so I'd rather not change that.