### PR TITLE
Added option to save unmodified screenshots

### DIFF
--- a/app/src/main/java/com/mathewsachin/fategrandautomata/ui/more/BattleGroup.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/ui/more/BattleGroup.kt
@@ -81,6 +81,14 @@ fun LazyListScope.battleGroup(
     }
 
     item {
+        prefs.screenshotDropsUnmodified.SwitchPreference(
+            title = stringResource(R.string.p_screenshot_drops_unmodified),
+            summary = stringResource(R.string.p_screenshot_drops_unmodified_summary),
+            icon = icon(R.drawable.ic_screenshot)
+        )
+    }
+
+    item {
         prefs.boostItemSelectionMode.SingleSelectChipPreference(
             title = stringResource(R.string.p_boost_item),
             icon = icon(Icons.Default.OfflineBolt),

--- a/app/src/main/res/values-b+zh+CN/localized.xml
+++ b/app/src/main/res/values-b+zh+CN/localized.xml
@@ -113,6 +113,8 @@
     <string name="p_stop_on_ce_get_summary">首次通关及羁绊礼装获得时自动停止脚本</string>
     <string name="p_screenshot_drops">掉落截图</string>
     <string name="p_screenshot_drops_summary">存至 \'drops\' 文件夹</string>
+    <string name="p_screenshot_drops_unmodified">Save unmodified screenshots</string>
+    <string name="p_screenshot_drops_unmodified_summary">Save unmodified full-screen screenshots instead of cropped and rescaled screenshots</string>
     <string name="p_boost_item">加速道具</string>
     <string name="p_brave_chains">追击连携</string>
     <string name="p_rearrange_cards">调换顺序\n(优先性高的卡后出)</string>

--- a/app/src/main/res/values-b+zh+TW/localized.xml
+++ b/app/src/main/res/values-b+zh+TW/localized.xml
@@ -114,6 +114,8 @@
     <string name="p_stop_on_ce_get_summary">首次通關及絆禮裝獲得時自動停止腳本</string>
     <string name="p_screenshot_drops">掉落截圖</string>
     <string name="p_screenshot_drops_summary">存至 \'drops\' 資料夾</string>
+    <string name="p_screenshot_drops_unmodified">Save unmodified screenshots</string>
+    <string name="p_screenshot_drops_unmodified_summary">Save unmodified full-screen screenshots instead of cropped and rescaled screenshots</string>
     <string name="p_boost_item">加速道具</string>
     <string name="p_brave_chains">Brave Chain</string>
     <string name="p_rearrange_cards">調換順序\n(優先性高的卡後出)</string>

--- a/app/src/main/res/values-ko/localized.xml
+++ b/app/src/main/res/values-ko/localized.xml
@@ -110,6 +110,8 @@
     <string name="p_stop_on_ce_get_summary">첫번째 퀘스트 클리어 보상과 인연예장(실험적 기능)</string>
     <string name="p_screenshot_drops">드롭 아이템 스크린샷</string>
     <string name="p_screenshot_drops_summary">\'drops\' 폴더에 저장되었습니다</string>
+    <string name="p_screenshot_drops_unmodified">Save unmodified screenshots</string>
+    <string name="p_screenshot_drops_unmodified_summary">Save unmodified full-screen screenshots instead of cropped and rescaled screenshots</string>
     <string name="p_boost_item">부스트 아이템</string>
     <string name="p_brave_chains">브레이브 체인</string>
     <string name="p_rearrange_cards">카드 재배열</string>
@@ -177,7 +179,7 @@
     <string name="p_script_mode_fp">친구 포인트 가챠</string>
     <string name="p_script_mode_support_image_maker">서포트 이미지 메이커</string>
     <string name="p_script_mode_gift_box">선물함</string>
-    <string name="p_max_gold_ember_set_size">4성 경험치 카드 개수</string>    
+    <string name="p_max_gold_ember_set_size">4성 경험치 카드 개수</string>
     <string name="p_not_set">설정 안함</string>
     <string name="p_support_class_none">없음</string>
     <string name="p_support_class_all">모두</string>

--- a/app/src/main/res/values/localized.xml
+++ b/app/src/main/res/values/localized.xml
@@ -129,6 +129,8 @@
     <string name="p_stop_on_ce_get_summary">First-time quest completion rewards and Bond CEs (Experimental)</string>
     <string name="p_screenshot_drops">Screenshot Drops</string>
     <string name="p_screenshot_drops_summary">Saved to \'drops\' folder</string>
+    <string name="p_screenshot_drops_unmodified">Save unmodified screenshots</string>
+    <string name="p_screenshot_drops_unmodified_summary">Save unmodified full-screen screenshots instead of cropped and rescaled screenshots</string>
     <string name="p_boost_item">Boost Item</string>
     <string name="p_brave_chains">Brave Chains</string>
     <string name="p_rearrange_cards">Rearrange Cards</string>

--- a/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/Preferences.kt
+++ b/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/Preferences.kt
@@ -74,6 +74,8 @@ class PreferencesImpl @Inject constructor(
 
     override val screenshotDrops by prefs.screenshotDrops
 
+    override val screenshotDropsUnmodified by prefs.screenshotDropsUnmodified
+
     override val stageCounterSimilarity by prefs.stageCounterSimilarity.map { it / 100.0 }
 
     override val stageCounterNew by prefs.stageCounterNew

--- a/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/core/PrefsCore.kt
+++ b/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/core/PrefsCore.kt
@@ -46,6 +46,7 @@ class PrefsCore @Inject constructor(
     val useRootForScreenshots = maker.bool("use_root_screenshot")
     val recordScreen = maker.bool("record_screen")
     val screenshotDrops = maker.bool("screenshot_drops")
+    val screenshotDropsUnmodified = maker.bool("screenshot_drops_unmodified")
     val debugMode = maker.bool("debug_mode")
     val autoStartService = maker.bool("auto_start_service")
 

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/ScreenshotDrops.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/ScreenshotDrops.kt
@@ -4,12 +4,14 @@ import com.mathewsachin.fategrandautomata.IStorageProvider
 import com.mathewsachin.fategrandautomata.scripts.IFgoAutomataApi
 import com.mathewsachin.fategrandautomata.scripts.Images
 import com.mathewsachin.libautomata.Pattern
+import com.mathewsachin.libautomata.ScreenshotService
 import com.mathewsachin.libautomata.dagger.ScriptScope
 import javax.inject.Inject
 
 @ScriptScope
 class ScreenshotDrops @Inject constructor(
     api: IFgoAutomataApi,
+    private val screenshotService: ScreenshotService,
     private val storageProvider: IStorageProvider
 ) : IFgoAutomataApi by api {
     fun screenshotDrops() {
@@ -20,7 +22,11 @@ class ScreenshotDrops @Inject constructor(
 
         for (i in 0..1) {
             useColor {
-                drops.add(locations.scriptArea.getPattern())
+                if (prefs.screenshotDropsUnmodified) {
+                    drops.add(screenshotService.takeScreenshot())
+                } else {
+                    drops.add(locations.scriptArea.getPattern())
+                }
             }
 
             // check if we need to scroll to see more drops

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/prefs/IPreferences.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/prefs/IPreferences.kt
@@ -24,6 +24,7 @@ interface IPreferences {
     val recordScreen: Boolean
     val skillDelay: Duration
     val screenshotDrops: Boolean
+    val screenshotDropsUnmodified: Boolean
     var maxGoldEmberSetSize: Int
     var stopAfterThisRun: Boolean
     val skipServantFaceCardCheck: Boolean


### PR DESCRIPTION
Added option to save unmodified screenshots instead of cropped and rescaled screenshots. This helps drop parser program locating the UI elements.

With cropped screenshots, drop parser program mistakenly assumes the phone has 16:9 aspect ratio.