### PR TITLE
Support Bronze Apples for refilling AP

### DIFF
--- a/app/src/main/java/com/mathewsachin/fategrandautomata/runner/ScriptManager.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/runner/ScriptManager.kt
@@ -107,10 +107,10 @@ class ScriptManager @Inject constructor(
                             recording.close()
                         }
                     } catch (e: Exception) {
-                        val msg = "Failed to stop recording"
+                        val msg = context.getString(R.string.cannot_stop_recording)
                         Timber.e(e, msg)
                         withContext(Dispatchers.Main) {
-                            Toast.makeText(service, msg, Toast.LENGTH_SHORT).show()
+                            Toast.makeText(service, "${msg}: ${e.message}", Toast.LENGTH_SHORT).show()
                         }
                     }
 
@@ -316,7 +316,7 @@ class ScriptManager @Inject constructor(
             val msg = context.getString(R.string.cannot_start_recording)
             Timber.e(e, msg)
             withContext(Dispatchers.Main) {
-                Toast.makeText(service, msg, Toast.LENGTH_SHORT).show()
+                Toast.makeText(service, "${msg}: ${e.message}", Toast.LENGTH_SHORT).show()
             }
 
             null

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/ui/launcher/BattleLauncher.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/ui/launcher/BattleLauncher.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.mathewsachin.fategrandautomata.R
+import com.mathewsachin.fategrandautomata.scripts.enums.GameServerEnum
 import com.mathewsachin.fategrandautomata.scripts.enums.RefillResourceEnum
 import com.mathewsachin.fategrandautomata.scripts.prefs.IPreferences
 import com.mathewsachin.fategrandautomata.ui.Stepper
@@ -71,8 +72,7 @@ fun battleLauncher(
                     Spacer(modifier.padding(16.dp))
                 }
             }
-        }
-        else {
+        } else {
             Text(
                 stringResource(R.string.battle_config_list_no_items),
                 modifier = Modifier
@@ -117,10 +117,17 @@ fun battleLauncher(
             LazyRow(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.End,
-                modifier = Modifier
-                    .fillMaxWidth()
+                modifier = Modifier.fillMaxWidth()
             ) {
-                items(RefillResourceEnum.values()) {
+                //only display bronze option for JP
+                val bronzeApplesEnabled = prefs.gameServer == GameServerEnum.Jp
+                if (!bronzeApplesEnabled) {
+                    //if the game server is not JP, disable it in the settings
+                    refillResources.minus(RefillResourceEnum.Bronze)
+                }
+                val availableRefills = RefillResourceEnum.values()
+                    .filter { it -> it != RefillResourceEnum.Bronze || bronzeApplesEnabled }
+                items(availableRefills) {
                     it.RefillResource(
                         isSelected = it in refillResources,
                         toggle = {
@@ -199,7 +206,7 @@ fun LimitItem(
     onCountChange: (Int) -> Unit,
     valueRange: IntRange = 1..999
 ) {
-    Row (
+    Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
         modifier = Modifier

--- a/app/src/main/java/com/mathewsachin/fategrandautomata/util/LocalizationExtensions.kt
+++ b/app/src/main/java/com/mathewsachin/fategrandautomata/util/LocalizationExtensions.kt
@@ -9,6 +9,7 @@ val RefillResourceEnum.stringRes
         RefillResourceEnum.Gold -> R.string.p_refill_type_gold
         RefillResourceEnum.Silver -> R.string.p_refill_type_silver
         RefillResourceEnum.Bronze -> R.string.p_refill_type_bronze
+        RefillResourceEnum.Copper -> R.string.p_refill_type_copper
     }
 
 val BraveChainEnum.stringRes

--- a/app/src/main/res/values-b+zh+CN/localized.xml
+++ b/app/src/main/res/values-b+zh+CN/localized.xml
@@ -169,7 +169,8 @@
 
     <string name="p_refill_type_gold">黃金果实</string>
     <string name="p_refill_type_silver">白银果实</string>
-    <string name="p_refill_type_bronze">赤铜果实</string>
+    <string name="p_refill_type_bronze">青铜果实</string>
+    <string name="p_refill_type_copper">赤铜果实</string>
     <string name="p_refill_type_sq">圣晶石</string>
 
     <string name="p_brave_chains_don_t_care">无偏好</string>

--- a/app/src/main/res/values-b+zh+TW/localized.xml
+++ b/app/src/main/res/values-b+zh+TW/localized.xml
@@ -171,7 +171,8 @@
 
     <string name="p_refill_type_gold">黃金果實</string>
     <string name="p_refill_type_silver">白銀果實</string>
-    <string name="p_refill_type_bronze">赤銅果實</string>
+    <string name="p_refill_type_bronze">青銅果實</string>
+    <string name="p_refill_type_copper">赤銅果實</string>
     <string name="p_refill_type_sq">聖晶石</string>
 
     <string name="p_brave_chains_don_t_care">無偏好</string>

--- a/app/src/main/res/values-ko/localized.xml
+++ b/app/src/main/res/values-ko/localized.xml
@@ -160,7 +160,8 @@
     <string name="p_nav_card_priority">카드 우선</string>
     <string name="p_refill_type_gold">금</string>
     <string name="p_refill_type_silver">은</string>
-    <string name="p_refill_type_bronze">동</string>
+    <string name="p_refill_type_bronze">청동</string>
+    <string name="p_refill_type_copper">동</string>
     <string name="p_refill_type_sq">성정석</string>
     <string name="p_brave_chains_don_t_care">상관 없음</string>
     <string name="p_brave_chains_with_np">보구랑 같이</string>

--- a/app/src/main/res/values/localized.xml
+++ b/app/src/main/res/values/localized.xml
@@ -235,7 +235,8 @@
     <string name="accessibility_disabled_go_to_settings">Go To Settings</string>
     <string name="draw_overlay_disabled_title">Missing overlay permission</string>
     <string name="draw_overlay_disabled_message">Please allow this app to draw over other apps. It is used to draw the control buttons.</string>
-    <string name="cannot_start_recording">Couldn\'t start recording</string>
+    <string name="cannot_start_recording">Failed to start recording</string>
+    <string name="cannot_stop_recording">Failed to stop recording</string>
     <string name="unexpected_error_copy">Copy</string>
 
     <string name="script_msg_ap_ran_out">AP ran out!</string>

--- a/app/src/main/res/values/localized.xml
+++ b/app/src/main/res/values/localized.xml
@@ -187,6 +187,7 @@
     <string name="p_refill_type_gold">Gold</string>
     <string name="p_refill_type_silver">Silver</string>
     <string name="p_refill_type_bronze">Bronze</string>
+    <string name="p_refill_type_copper">Copper</string>
     <string name="p_refill_type_sq">SQ</string>
 
     <string name="p_brave_chains_don_t_care">Don\'t care</string>

--- a/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/Preferences.kt
+++ b/prefs/src/main/java/com/mathewsachin/fategrandautomata/prefs/Preferences.kt
@@ -6,7 +6,6 @@ import com.mathewsachin.fategrandautomata.scripts.enums.GameServerEnum
 import com.mathewsachin.fategrandautomata.scripts.prefs.*
 import com.mathewsachin.libautomata.PlatformPrefs
 import javax.inject.Inject
-import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
 class PreferencesImpl @Inject constructor(

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/enums/RefillResourceEnum.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/enums/RefillResourceEnum.kt
@@ -1,6 +1,7 @@
 package com.mathewsachin.fategrandautomata.scripts.enums
 
 enum class RefillResourceEnum {
+    Copper,
     Bronze,
     Silver,
     Gold,

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/locations/Locations.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/locations/Locations.kt
@@ -57,8 +57,8 @@ class Locations @Inject constructor(
     fun locate(refillResource: RefillResourceEnum): List<Location> {
         //scroll bar click location
         val scrollBarLoc = when (refillResource) {
-            RefillResourceEnum.Copper -> 980
-            else -> 380
+            RefillResourceEnum.Copper -> 1040
+            else -> 300
         }.let { y -> Location(750, y).xFromCenter() }
 
         val resourceLoc = when (refillResource) {

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/locations/Locations.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/locations/Locations.kt
@@ -16,7 +16,7 @@ class Locations @Inject constructor(
     val support: SupportScreenLocations,
     val attack: AttackScreenLocations,
     val battle: BattleScreenLocations
-): IScriptAreaTransforms by scriptAreaTransforms {
+) : IScriptAreaTransforms by scriptAreaTransforms {
 
     val continueRegion = Region(120, 1000, 800, 200).xFromCenter()
     val continueBoostClick = Location(-20, 1120).xFromCenter()
@@ -54,12 +54,22 @@ class Locations @Inject constructor(
     val withdrawAcceptClick = Location(485, 720).xFromCenter()
     val withdrawCloseClick = Location(-10, 1140).xFromCenter()
 
-    fun locate(refillResource: RefillResourceEnum) = when (refillResource) {
-        RefillResourceEnum.Bronze -> 1140
-        RefillResourceEnum.Silver -> 922
-        RefillResourceEnum.Gold -> 634
-        RefillResourceEnum.SQ -> 345
-    }.let { y -> Location(-530, y).xFromCenter() }
+    fun locate(refillResource: RefillResourceEnum): List<Location> {
+        //scroll bar click location
+        val scrollBarLoc = when (refillResource) {
+            RefillResourceEnum.Copper -> 980
+            else -> 380
+        }.let { y -> Location(750, y).xFromCenter() }
+
+        val resourceLoc = when (refillResource) {
+            RefillResourceEnum.Copper -> 980
+            RefillResourceEnum.Bronze -> 1140
+            RefillResourceEnum.Silver -> 922
+            RefillResourceEnum.Gold -> 634
+            RefillResourceEnum.SQ -> 345
+        }.let { y -> Location(-530, y).xFromCenter() }
+        return listOf(scrollBarLoc, resourceLoc)
+    }
 
     fun locate(boost: BoostItem.Enabled) = when (boost) {
         BoostItem.Enabled.Skip -> Location(1652, 1304)

--- a/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/Refill.kt
+++ b/scripts/src/main/java/com/mathewsachin/fategrandautomata/scripts/modules/Refill.kt
@@ -26,7 +26,7 @@ class Refill @Inject constructor(
             && timesRefilled < refill.repetitions
         ) {
             refill.resources
-                .map { locations.locate(it) }
+                .flatMap { locations.locate(it) }
                 .forEach { it.click() }
 
             1.seconds.wait()


### PR DESCRIPTION
The old "bronze" apples were renamed to "copper".

Fixes #1178.