### PR TITLE
[i18n] Fix typo to text on official KR service

### DIFF
--- a/app/src/main/res/values-ko/localized.xml
+++ b/app/src/main/res/values-ko/localized.xml
@@ -328,7 +328,7 @@
     <string name="mat_arrow">재난의 화살촉</string>
     <string name="mat_tiara">광은의 관</string>
     <string name="mat_particle">신맥영자</string>
-    <string name="mat_thread">무지개 실구슬</string>
+    <string name="mat_thread">무지갯빛 실타리</string>
     <string name="mat_mirror">구십구경</string>
     <string name="mat_egg">진리의 알</string>
     <string name="mat_star_shard">황성의 조각</string>


### PR DESCRIPTION
from `"무지개 실구슬"` to `"무지갯빛 실타래"`