### PR TITLE
update np color based on position

### DIFF
--- a/app/src/main/java/io/github/fate_grand_automata/ui/skill_maker/SkillMakerAtk.kt
+++ b/app/src/main/java/io/github/fate_grand_automata/ui/skill_maker/SkillMakerAtk.kt
@@ -56,10 +56,10 @@ private fun SelectNps(
 
             val canSelect = numberOfCardsSelected + numberOfNPs + 1 <= 3
 
-            val selectedColor = when (servantNumber) {
-                1 -> R.color.colorServant1
-                2 -> R.color.colorServant2
-                3 -> R.color.colorServant3
+            val selectedColor = when (npSequence.indexOf("$servantNumber")) {
+                0 -> R.color.colorServant1
+                1 -> R.color.colorServant2
+                2 -> R.color.colorServant3
                 else -> R.color.colorAccent
             }
 


### PR DESCRIPTION
This enables to show the order of NP by color instead of static color per NP

1st NP   Red
2nd NP Blue
3rd NP  Orange

![HD-Player_FOjAjSRBRn](https://github.com/Fate-Grand-Automata/FGA/assets/16458204/a88e619d-8346-4ea5-a43c-f1d0317016fb)
