### PR TITLE
Animation Skip after the support selection

### DIFF
--- a/scripts/src/main/java/io/github/fate_grand_automata/scripts/entrypoints/AutoBattle.kt
+++ b/scripts/src/main/java/io/github/fate_grand_automata/scripts/entrypoints/AutoBattle.kt
@@ -445,11 +445,11 @@ class AutoBattle @Inject constructor(
                 images[Images.SelectedParty],
                 timeout = 5.seconds
             )
-            if (partyVanish){
+            if (partyVanish && prefs.storySkip){
                 1.seconds.wait()
                 locations.animationSkipLocation.click()
-                5.seconds.wait()
             }
+            5.seconds.wait()
         }
     }
 

--- a/scripts/src/main/java/io/github/fate_grand_automata/scripts/entrypoints/AutoBattle.kt
+++ b/scripts/src/main/java/io/github/fate_grand_automata/scripts/entrypoints/AutoBattle.kt
@@ -448,6 +448,7 @@ class AutoBattle @Inject constructor(
             if (partyVanish){
                 1.seconds.wait()
                 locations.animationSkipLocation.click()
+                5.seconds.wait()
             }
         }
     }

--- a/scripts/src/main/java/io/github/fate_grand_automata/scripts/entrypoints/AutoBattle.kt
+++ b/scripts/src/main/java/io/github/fate_grand_automata/scripts/entrypoints/AutoBattle.kt
@@ -440,7 +440,15 @@ class AutoBattle @Inject constructor(
             // Wait timer till battle starts.
             // Uses less battery to wait than to search for images for a few seconds.
             // Adjust according to device.
-            5.seconds.wait()
+            // 5.seconds.wait()
+            val partyVanish = locations.selectedPartyRegion.waitVanish(
+                images[Images.SelectedParty],
+                timeout = 5.seconds
+            )
+            if (partyVanish){
+                1.seconds.wait()
+                locations.animationSkipLocation.click()
+            }
         }
     }
 

--- a/scripts/src/main/java/io/github/fate_grand_automata/scripts/locations/Locations.kt
+++ b/scripts/src/main/java/io/github/fate_grand_automata/scripts/locations/Locations.kt
@@ -166,4 +166,6 @@ class Locations @Inject constructor(
     val enhancementSkipRapidClick = Location(0, 1400).xFromCenter()
 
     val tempServantEnhancementLocation = Location(402, 1124).xFromCenter()
+
+    val animationSkipLocation = menuStorySkipClick - Location(200, 0)
 }

--- a/scripts/src/main/java/io/github/fate_grand_automata/scripts/locations/Locations.kt
+++ b/scripts/src/main/java/io/github/fate_grand_automata/scripts/locations/Locations.kt
@@ -149,4 +149,6 @@ class Locations @Inject constructor(
     val enhancementSkipRapidClick = Location(0, 1400).xFromCenter()
 
     val tempServantEnhancementLocation = Location(402, 1124).xFromCenter()
+
+    val animationSkipLocation = menuStorySkipClick - Location(200, 0)
 }


### PR DESCRIPTION
There is some animation in between Support and Skip button, this aims to solved that.

Check for the selected party and if it vanishes then we managed to get out of support and we can now click the animation

![skip_animation_region](https://github.com/Fate-Grand-Automata/FGA/assets/16458204/ce58af75-c510-4486-b084-5eda43ae6114)
