### PR TITLE
Enable to wait for AP at the last run

### DIFF
--- a/scripts/src/main/java/io/github/fate_grand_automata/scripts/entrypoints/AutoBattle.kt
+++ b/scripts/src/main/java/io/github/fate_grand_automata/scripts/entrypoints/AutoBattle.kt
@@ -531,6 +531,11 @@ class AutoBattle @Inject constructor(
             inventoryFull -> throw BattleExitException(ExitReason.InventoryFull)
         }
 
-        refill.refill()
+        val isLastRun = prefs.selectedServerConfigPref.shouldLimitRuns &&
+                (prefs.selectedServerConfigPref.limitRuns - state.runs) <= 1
+
+        refill.refill(
+            isLastRun = isLastRun
+        )
     }
 }

--- a/scripts/src/main/java/io/github/fate_grand_automata/scripts/modules/Refill.kt
+++ b/scripts/src/main/java/io/github/fate_grand_automata/scripts/modules/Refill.kt
@@ -4,6 +4,7 @@ import io.github.fate_grand_automata.scripts.IFgoAutomataApi
 import io.github.fate_grand_automata.scripts.Images
 import io.github.fate_grand_automata.scripts.ScriptNotify
 import io.github.fate_grand_automata.scripts.entrypoints.AutoBattle
+import io.github.fate_grand_automata.scripts.prefs.IPerServerConfigPrefs
 import io.github.lib_automata.dagger.ScriptScope
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
@@ -19,34 +20,61 @@ class Refill @Inject constructor(
      * Refills the AP with apples depending on preferences.
      * If needed, loops and wait for AP regeneration
      */
-    private fun refillOnce() {
+    private fun refillOnce(
+        isLastRun: Boolean = false
+    ) {
         val perServerConfigPref = prefs.selectedServerConfigPref
 
-        if (perServerConfigPref.resources.isNotEmpty()
-            && timesRefilled < perServerConfigPref.currentAppleCount
-        ) {
-            //TODO check for OK image between each resource
-            perServerConfigPref.resources
-                .flatMap { locations.locate(it) }
-                .forEach { it.click() }
+        when {
+            /**
+             * If the user has resources to refill and has the wait for AP regen option enabled
+             * and this is the last run, wait for AP regen instead of refilling.
+             */
+            perServerConfigPref.waitForAPRegen && isLastRun -> waitForAPRegen()
+            /**
+             * If the user has resources to refill and has not reached the current apple count,
+             */
+            perServerConfigPref.resources.isNotEmpty() && timesRefilled < perServerConfigPref.currentAppleCount -> {
+                refillAP(perServerConfigPref = perServerConfigPref)
+            }
+            /**
+             * wait for AP regen if the user has the wait for AP regen option enabled
+             */
 
-            1.seconds.wait()
-            locations.staminaOkClick.click()
-            ++timesRefilled
+            perServerConfigPref.waitForAPRegen -> waitForAPRegen()
 
-            3.seconds.wait()
-        } else if (perServerConfigPref.waitForAPRegen) {
-            locations.staminaCloseClick.click()
-
-            messages.notify(ScriptNotify.WaitForAPRegen())
-
-            60.seconds.wait()
-        } else throw AutoBattle.BattleExitException(AutoBattle.ExitReason.APRanOut)
+            else -> throw AutoBattle.BattleExitException(AutoBattle.ExitReason.APRanOut)
+        }
     }
 
-    fun refill() {
+    private fun refillAP(perServerConfigPref: IPerServerConfigPrefs) {
+        //TODO check for OK image between each resource
+        perServerConfigPref.resources
+            .flatMap { locations.locate(it) }
+            .forEach { it.click() }
+
+        1.seconds.wait()
+        locations.staminaOkClick.click()
+        ++timesRefilled
+
+        3.seconds.wait()
+    }
+
+    private fun waitForAPRegen() {
+        locations.staminaCloseClick.click()
+
+        messages.notify(ScriptNotify.WaitForAPRegen())
+
+        60.seconds.wait()
+    }
+
+    fun refill(
+        isLastRun: Boolean = false
+    ) {
         if (images[Images.Stamina] in locations.staminaScreenRegion) {
-            refillOnce()
+            refillOnce(
+                isLastRun = isLastRun
+            )
         }
     }
 


### PR DESCRIPTION
# Enable to wait for AP for the last run

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [X] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
This PR updates the refill logic.

When the user has both the `should limit runs` and `wait for AP` options enabled. It would wait for the AP on the very last run instead of refilling with apples

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Additional context
<!-- Add any other context about the pull request here. -->
