### PR TITLE
Raid delay

### DIFF
--- a/app/src/main/java/io/github/fate_grand_automata/ui/battle_config_item/BattleConfigScreen.kt
+++ b/app/src/main/java/io/github/fate_grand_automata/ui/battle_config_item/BattleConfigScreen.kt
@@ -219,7 +219,15 @@ private fun BattleConfigContent(
                                         modifier = Modifier
                                             .padding(16.dp, 5.dp)
                                     )
-                                }
+                                }                            
+                            }
+
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier
+                                    .height(IntrinsicSize.Min)
+                            ) {
+                                RaidDelay(config=config)
 
                                 VerticalDivider()
 

--- a/app/src/main/java/io/github/fate_grand_automata/ui/battle_config_item/RaidDelay.kt
+++ b/app/src/main/java/io/github/fate_grand_automata/ui/battle_config_item/RaidDelay.kt
@@ -1,0 +1,183 @@
+package io.github.fate_grand_automata.ui.battle_config_item
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import io.github.fate_grand_automata.R
+import io.github.fate_grand_automata.prefs.core.BattleConfigCore
+import io.github.fate_grand_automata.ui.Stepper
+import io.github.fate_grand_automata.ui.dialog.FgaDialog
+import io.github.fate_grand_automata.ui.prefs.remember
+
+@Composable
+fun RaidDelay(
+    modifier: Modifier = Modifier,
+    config: BattleConfigCore
+) {
+    var addRaidTurnDelay by config.addRaidTurnDelay.remember()
+
+    var raidTurnDelaySeconds by config.raidTurnDelaySeconds.remember()
+
+    val dialog = FgaDialog()
+
+    dialog.build(
+        color = MaterialTheme.colorScheme.background
+    ) {
+        var currentAddRaidTurnDelay by remember(addRaidTurnDelay) { mutableStateOf(addRaidTurnDelay) }
+        var currentRaidTurnDelaySeconds by remember(raidTurnDelaySeconds) { mutableStateOf(raidTurnDelaySeconds) }
+
+        Row {
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .alignByBaseline()
+            ) {
+                title(stringResource(R.string.p_battle_config_raid_delay))
+            }
+
+            TextButton(
+                onClick = {
+                    currentAddRaidTurnDelay = config.addRaidTurnDelay.defaultValue
+                    currentRaidTurnDelaySeconds = config.raidTurnDelaySeconds.defaultValue
+                },
+                modifier = Modifier
+                    .padding(16.dp, 5.dp)
+                    .alignByBaseline(),
+            ) {
+                Text(
+                    stringResource(id = R.string.reset).uppercase()
+                )
+            }
+        }
+
+        message(text = stringResource(R.string.p_battle_config_raid_delay_message))
+
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Card(
+                    shape = RoundedCornerShape(25),
+                    colors = CardDefaults.cardColors(
+                        containerColor =
+                        if (currentAddRaidTurnDelay) MaterialTheme.colorScheme.primaryContainer
+                        else MaterialTheme.colorScheme.surfaceVariant
+                    ),
+                    onClick = {
+                        currentAddRaidTurnDelay = true
+                    },
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(horizontal = 2.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.state_on).uppercase(),
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp),
+                        textAlign = TextAlign.Center,
+                        fontWeight = if (currentAddRaidTurnDelay) FontWeight.Bold else null
+                    )
+                }
+                Card(
+                    shape = RoundedCornerShape(25),
+                    colors = CardDefaults.cardColors(
+                        containerColor =
+                        if (!currentAddRaidTurnDelay) MaterialTheme.colorScheme.primaryContainer
+                        else MaterialTheme.colorScheme.surfaceVariant
+                    ),
+                    onClick = {
+                        currentAddRaidTurnDelay = false
+                    },
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(horizontal = 2.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.state_off).uppercase(),
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp),
+                        textAlign = TextAlign.Center,
+                        fontWeight = if (!currentAddRaidTurnDelay) FontWeight.Bold else null
+                    )
+                }
+            }
+
+            if (currentAddRaidTurnDelay) {
+                Stepper(
+                    value = currentRaidTurnDelaySeconds,
+                    onValueChange = {
+                        currentRaidTurnDelaySeconds = it
+                    },
+                    valueRange = 1..10,
+                    valueRepresentation = {
+                        "${it}s"
+                    }
+                )
+            }
+            buttons(
+                onSubmit = {
+                    addRaidTurnDelay = currentAddRaidTurnDelay
+                    raidTurnDelaySeconds = currentRaidTurnDelaySeconds
+                },
+                okLabel = stringResource(R.string.save),
+            )
+        }
+
+
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxHeight()
+            .clickable(
+                onClick = { dialog.show() }
+            )
+            .padding(16.dp, 5.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            stringResource(R.string.p_battle_config_raid).uppercase(),
+            style = MaterialTheme.typography.bodySmall
+        )
+
+        Text(
+            text = when (addRaidTurnDelay) {
+                true -> "${raidTurnDelaySeconds}s"
+                false -> stringResource(R.string.state_off).uppercase()
+            },
+            style = MaterialTheme.typography.bodySmall
+        )
+    }
+}

--- a/app/src/main/res/values/localized.xml
+++ b/app/src/main/res/values/localized.xml
@@ -480,4 +480,5 @@ After pressing on the button, switch the app filter from \"Not optimized\" to \"
     <string name="state_on">On</string>
     <string name="state_off">Off</string>
     <string name="save">Save</string>
+    <string name="reset">reset</string>
 </resources>

--- a/app/src/main/res/values/localized.xml
+++ b/app/src/main/res/values/localized.xml
@@ -473,4 +473,11 @@ After pressing on the button, switch the app filter from \"Not optimized\" to \"
     <string name="servant_enhancement_none_selected">No Servant Selected. Please select a Servant before proceeding.</string>
     <string name="servant_enhancement_aborted">Enhancement was aborted</string>
     <string name="note">"Note:"</string>
+
+    <string name="p_battle_config_raid">"Raid"</string>
+    <string name="p_battle_config_raid_delay">"Raid Delay"</string>
+    <string name="p_battle_config_raid_delay_message">This adds extra turn delay used for raids.</string>
+    <string name="state_on">On</string>
+    <string name="state_off">Off</string>
+    <string name="save">Save</string>
 </resources>

--- a/prefs/src/main/java/io/github/fate_grand_automata/prefs/BattleConfig.kt
+++ b/prefs/src/main/java/io/github/fate_grand_automata/prefs/BattleConfig.kt
@@ -42,6 +42,10 @@ internal class BattleConfig(
         }
     )
 
+    override val addRaidTurnDelay by prefs.addRaidTurnDelay
+
+    override val raidTurnDelaySeconds by prefs.raidTurnDelaySeconds
+
     override var spam by prefs.spam
 
     override fun export(): Map<String, *> = prefs.export()

--- a/prefs/src/main/java/io/github/fate_grand_automata/prefs/core/BattleConfigCore.kt
+++ b/prefs/src/main/java/io/github/fate_grand_automata/prefs/core/BattleConfigCore.kt
@@ -185,4 +185,8 @@ class BattleConfigCore(
     val support = SupportPrefsCore(maker)
 
     val autoChooseTarget = maker.bool("auto_choose_target")
+
+    val addRaidTurnDelay = maker.bool("add_raid_delay")
+
+    val raidTurnDelaySeconds = maker.stringAsInt("raid_delay_seconds", 3)
 }

--- a/scripts/src/main/java/io/github/fate_grand_automata/scripts/modules/Battle.kt
+++ b/scripts/src/main/java/io/github/fate_grand_automata/scripts/modules/Battle.kt
@@ -69,6 +69,11 @@ class Battle @Inject constructor(
         prefs.waitBeforeTurn.wait()
 
         onTurnStarted()
+
+        if (battleConfig.addRaidTurnDelay){
+            battleConfig.raidTurnDelaySeconds.seconds.wait()
+        }
+
         servantTracker.beginTurn()
 
         val npUsage = autoSkill.execute(state.stage, state.turn)

--- a/scripts/src/main/java/io/github/fate_grand_automata/scripts/prefs/IBattleConfig.kt
+++ b/scripts/src/main/java/io/github/fate_grand_automata/scripts/prefs/IBattleConfig.kt
@@ -28,6 +28,9 @@ interface IBattleConfig {
 
     val server: GameServer?
 
+    val addRaidTurnDelay: Boolean
+    val raidTurnDelaySeconds : Int
+
     fun export(): Map<String, *>
 
     fun import(map: Map<String, *>)


### PR DESCRIPTION
# Raid delay

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [X] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
fixes #1720

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Current JP Raid have the same mechanics as the Tunguska. Where it shows the remaining kills which causes the script to unable to perform the next turn commands. This PR aims to add functionality to delay the before the turn starts to solved this problem.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
![raid message](https://github.com/user-attachments/assets/ba6b6034-e22c-4f5f-8eff-3ec656b2d531)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Additional context
<!-- Add any other context about the pull request here. -->
