### PR TITLE
Updated JP Repeat Button Location

### DIFF
--- a/scripts/src/main/java/io/github/fate_grand_automata/scripts/locations/Locations.kt
+++ b/scripts/src/main/java/io/github/fate_grand_automata/scripts/locations/Locations.kt
@@ -21,7 +21,10 @@ class Locations @Inject constructor(
     val servant: ServantLevelLocations,
 ) : IScriptAreaTransforms by scriptAreaTransforms {
 
-    val continueRegion = Region(120, 1000, 800, 200).xFromCenter()
+    val continueRegion = when (gameServer) {
+        is GameServer.Jp -> Region(120, 1100, 800, 200).xFromCenter()
+        else -> Region(120, 1000, 800, 200).xFromCenter()
+    }
     val continueBoostClick = Location(-20, 1120).xFromCenter()
 
     val inventoryFullRegion = Region(-280, 860, 560, 190).xFromCenter()


### PR DESCRIPTION
# fix(AutoBattle): New JP Repeat Button Location

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
- fixes #1953

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The new Teapot and storm pod UI have adjusted the repeat button location in JP. This PR aims to fix this

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
![407703079-57e82979-4900-4300-80c7-2f1182b39cb7-1](https://github.com/user-attachments/assets/9b4366a9-84cd-49e1-858d-2454fe0e2dce)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
1. Select Any Quest
2. Make at least 2 runs
3. Make sure it select the repeat button to enter the next run

## Additional context
<!-- Add any other context about the pull request here. -->
