### PR TITLE
Fix Opencv Crash Region out of bounds

### DIFF
--- a/app/src/main/java/io/github/fate_grand_automata/imaging/DroidCvPattern.kt
+++ b/app/src/main/java/io/github/fate_grand_automata/imaging/DroidCvPattern.kt
@@ -75,7 +75,7 @@ class DroidCvPattern(
         target.tag = tag
     }
 
-    private fun match(template: Pattern): Mat {
+    private fun match(template: Pattern): Mat? {
         val result = Mat()
         if (template is DroidCvPattern) {
             if (template.width <= width && template.height <= height) {
@@ -85,18 +85,18 @@ class DroidCvPattern(
                     result,
                     Imgproc.TM_CCOEFF_NORMED
                 )
+                return result
             } else {
                 Timber.v("Skipped matching $template: Region out of bounds")
             }
         }
-
-        return result
+        return null  
     }
 
     override fun findMatches(template: Pattern, similarity: Double) = sequence {
         val result = match(template)
 
-        result.use {
+        result?.use {
             while (true) {
                 val minMaxLocResult = Core.minMaxLoc(it)
                 val score = minMaxLocResult.maxVal


### PR DESCRIPTION
# Opencv Crash Region out of bounds

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other 

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
- fixes #2002 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
For some odd reason, I encountered a problem wherein when checking support's skills and it was out of frame(only the servant image was visible and it matched with the template) it would led to crash. Changing the mat to null-able resolves this issue.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
1. Ensure the battle config has a servant selected and skills enabled.
2. Go to the support screen.
3. Find the servant and when found, scroll the screen and ensure that the servant is visible but not the skills.
4. Run the script
5. ....
6. Crash!

## Additional context
<!-- Add any other context about the pull request here. -->
This is edge case but damn