### PR TITLE
feat: tesseract improvements

### DIFF
--- a/app/src/main/java/io/github/fate_grand_automata/di/script/ScriptsModule.kt
+++ b/app/src/main/java/io/github/fate_grand_automata/di/script/ScriptsModule.kt
@@ -5,7 +5,6 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import io.github.fate_grand_automata.accessibility.AccessibilityGestures
-import io.github.fate_grand_automata.imaging.TesseractOcrService
 import io.github.fate_grand_automata.scripts.FgoAutomataApi
 import io.github.fate_grand_automata.scripts.FgoGameAreaManager
 import io.github.fate_grand_automata.scripts.IFgoAutomataApi
@@ -15,7 +14,6 @@ import io.github.fate_grand_automata.scripts.modules.RealSupportScreen
 import io.github.fate_grand_automata.scripts.modules.SupportScreen
 import io.github.lib_automata.GameAreaManager
 import io.github.lib_automata.GestureService
-import io.github.lib_automata.OcrService
 import io.github.lib_automata.PlatformImpl
 import io.github.lib_automata.dagger.ScriptScope
 
@@ -47,8 +45,4 @@ abstract class ScriptsModule {
     @ScriptScope
     @Binds
     abstract fun supportScreen(screen: RealSupportScreen): SupportScreen
-
-    @ScriptScope
-    @Binds
-    abstract fun bindOcrService(ocrService: TesseractOcrService): OcrService
 }

--- a/app/src/main/java/io/github/fate_grand_automata/di/service/ServiceModule.kt
+++ b/app/src/main/java/io/github/fate_grand_automata/di/service/ServiceModule.kt
@@ -5,9 +5,11 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ServiceComponent
 import dagger.hilt.android.scopes.ServiceScoped
+import io.github.fate_grand_automata.imaging.TesseractOcrService
 import io.github.fate_grand_automata.scripts.IScriptMessages
 import io.github.fate_grand_automata.util.AndroidImpl
 import io.github.fate_grand_automata.util.ScriptMessages
+import io.github.lib_automata.OcrService
 import io.github.lib_automata.PlatformImpl
 
 @Module
@@ -20,4 +22,8 @@ interface ServiceModule {
     @ServiceScoped
     @Binds
     fun bindScriptMessages(scriptMessages: ScriptMessages): IScriptMessages
+
+    @ServiceScoped
+    @Binds
+    fun bindOcrService(ocrService: TesseractOcrService): OcrService
 }

--- a/app/src/main/java/io/github/fate_grand_automata/imaging/TesseractOcrService.kt
+++ b/app/src/main/java/io/github/fate_grand_automata/imaging/TesseractOcrService.kt
@@ -11,6 +11,7 @@ import java.security.MessageDigest
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
+import java.io.InputStream
 import java.io.IOException
 import javax.inject.Inject
 

--- a/app/src/main/java/io/github/fate_grand_automata/imaging/TesseractOcrService.kt
+++ b/app/src/main/java/io/github/fate_grand_automata/imaging/TesseractOcrService.kt
@@ -50,7 +50,7 @@ class TesseractOcrService @Inject constructor(
             val targetFile = File(tessDir, assetFileName)
             val assetPath = "tessdata/$assetFileName"
             if (!targetFile.exists()) {
-                copyFile(assetPath, File(tessDir, assetFileName))
+                copyFile(assetPath, targetFile)
             }
         }
     }

--- a/app/src/main/java/io/github/fate_grand_automata/imaging/TesseractOcrService.kt
+++ b/app/src/main/java/io/github/fate_grand_automata/imaging/TesseractOcrService.kt
@@ -48,18 +48,19 @@ class TesseractOcrService @Inject constructor(
         }
         for (assetFileName in context.assets.list("tessdata")!!) {
             val targetFile = File(tessDir, assetFileName)
+            val assetPath = "tessdata/$assetFileName"
             if (!targetFile.exists()) {
-                copyFile(context.assets, "tessdata/$assetFileName", File(tessDir, assetFileName))
+                copyFile(assetPath, File(tessDir, assetFileName))
             }
         }
     }
 
     private fun copyFile(
-        am: AssetManager, assetName: String,
+        assetName: String,
         outFile: File
     ) {
         try {
-            am.open(assetName).use { `in` ->
+            context.assets.open(assetName).use { `in` ->
                 FileOutputStream(outFile).use { out ->
                     val buffer = ByteArray(1024)
                     var read: Int

--- a/app/src/main/java/io/github/fate_grand_automata/imaging/TesseractOcrService.kt
+++ b/app/src/main/java/io/github/fate_grand_automata/imaging/TesseractOcrService.kt
@@ -8,6 +8,7 @@ import dagger.hilt.android.scopes.ServiceScoped
 import io.github.lib_automata.OcrService
 import io.github.lib_automata.Pattern
 import timber.log.Timber
+import java.security.MessageDigest
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -45,7 +46,34 @@ class TesseractOcrService @Inject constructor(
         for (assetFileName in context.assets.list("tessdata")!!) {
             val targetFile = File(tessDir, assetFileName)
             val assetPath = "tessdata/$assetFileName"
-            if (!targetFile.exists()) {
+
+            val assetHash = calculateAssetHash(assetPath)
+            if (assetHash == null) {
+                Timber.w("Could not calculate hash for asset: $assetPath. Skipping check.")
+                // Fallback to simple existence check or force copy if needed
+                if (!targetFile.exists()) {
+                        copyFile(assetPath, targetFile)
+                } else {
+                    Timber.d("File exists, but couldn't verify hash: $targetFile")
+                }
+                continue // Move to next file
+            }
+
+            var needsCopy = true
+            if (targetFile.exists()) {
+                val targetHash = calculateFileHash(targetFile)
+                if (targetHash != null && assetHash == targetHash) {
+                    Timber.d("File already exists and hash matches: $targetFile")
+                    needsCopy = false
+                } else if (targetHash == null) {
+                    Timber.w("Could not calculate hash for existing file: $targetFile. Will overwrite.")
+                } else {
+                    Timber.d("Hash mismatch for $targetFile. Asset hash: $assetHash, File hash: $targetHash. Overwriting.")
+                }
+            } else {
+                Timber.d("File does not exist: $targetFile. Copying.")
+            }
+            if (needsCopy) {
                 copyFile(assetPath, targetFile)
             }
         }
@@ -68,6 +96,39 @@ class TesseractOcrService @Inject constructor(
         } catch (e: IOException) {
             e.printStackTrace()
         }
+    }
+
+    private fun calculateAssetHash(assetPath: String): String? {
+        return try {
+            context.assets.open(assetPath).use { inputStream ->
+                calculateStreamHash(inputStream)
+            }
+        } catch (e: IOException) {
+            Timber.e(e, "Failed to calculate hash for asset: $assetPath")
+            null
+        }
+    }
+
+    private fun calculateFileHash(file: File): String? {
+        return try {
+            FileInputStream(file).use { inputStream ->
+                calculateStreamHash(inputStream)
+            }
+        } catch (e: IOException) {
+            Timber.e(e, "Failed to calculate hash for file: ${file.absolutePath}")
+            null
+        }
+    }
+
+    private fun calculateStreamHash(inputStream: InputStream): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val buffer = ByteArray(1024)
+        var bytesRead: Int
+        while (inputStream.read(buffer).also { bytesRead = it } != -1) {
+            digest.update(buffer, 0, bytesRead)
+        }
+        // Convert byte array to Hex String
+        return digest.digest().joinToString("") { "%02x".format(it) }
     }
 
     override fun close() {

--- a/app/src/main/java/io/github/fate_grand_automata/imaging/TesseractOcrService.kt
+++ b/app/src/main/java/io/github/fate_grand_automata/imaging/TesseractOcrService.kt
@@ -37,10 +37,6 @@ class TesseractOcrService @Inject constructor(
         }
     }
 
-    protected fun finalize() {
-        tessApi.recycle()
-    }
-
     private fun extractTesseractTrainingData() {
         val tessDir = File(context.filesDir.absolutePath, "tessdata")
         if (!tessDir.exists()) {

--- a/app/src/main/java/io/github/fate_grand_automata/imaging/TesseractOcrService.kt
+++ b/app/src/main/java/io/github/fate_grand_automata/imaging/TesseractOcrService.kt
@@ -55,7 +55,12 @@ class TesseractOcrService @Inject constructor(
         if (!tessDir.exists()) {
             tessDir.mkdir()
         }
-        for (assetFileName in context.assets.list("tessdata")!!) {
+        val assetList = context.assets.list("tessdata")
+        if (assetList == null) {
+            Timber.e("Failed to list assets in tessdata")
+            return
+        }
+        for (assetFileName in assetList) {
             val targetFile = File(tessDir, assetFileName)
             val assetPath = "tessdata/$assetFileName"
 

--- a/app/src/main/java/io/github/fate_grand_automata/imaging/TesseractOcrService.kt
+++ b/app/src/main/java/io/github/fate_grand_automata/imaging/TesseractOcrService.kt
@@ -1,7 +1,6 @@
 package io.github.fate_grand_automata.imaging
 
 import android.content.Context
-import android.content.res.AssetManager
 import com.googlecode.tesseract.android.TessBaseAPI
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.scopes.ServiceScoped

--- a/app/src/main/java/io/github/fate_grand_automata/imaging/TesseractOcrService.kt
+++ b/app/src/main/java/io/github/fate_grand_automata/imaging/TesseractOcrService.kt
@@ -9,6 +9,7 @@ import io.github.lib_automata.Pattern
 import timber.log.Timber
 import java.security.MessageDigest
 import java.io.File
+import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.IOException
 import javax.inject.Inject

--- a/app/src/main/java/io/github/fate_grand_automata/imaging/TesseractOcrService.kt
+++ b/app/src/main/java/io/github/fate_grand_automata/imaging/TesseractOcrService.kt
@@ -93,7 +93,9 @@ class TesseractOcrService @Inject constructor(
                 }
             }
         } catch (e: IOException) {
-            e.printStackTrace()
+            Timber.e(e, "Failed to copy file from assets to $outFile")
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to copy file from assets to $outFile")
         }
     }
 

--- a/app/src/main/java/io/github/fate_grand_automata/runner/ScriptRunnerServiceController.kt
+++ b/app/src/main/java/io/github/fate_grand_automata/runner/ScriptRunnerServiceController.kt
@@ -14,6 +14,7 @@ import io.github.fate_grand_automata.util.DisplayHelper
 import io.github.fate_grand_automata.util.ImageLoader
 import io.github.fate_grand_automata.util.ScreenOffReceiver
 import io.github.fate_grand_automata.util.ScriptMessages
+import io.github.lib_automata.OcrService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
@@ -36,6 +37,7 @@ class ScriptRunnerServiceController @Inject constructor(
     private val displayHelper: DisplayHelper,
     private val messages: ScriptMessages,
     private val messageBox: ScriptRunnerMessageBox,
+    private val ocrService: OcrService,
     @ServiceCoroutineScope private val scope: CoroutineScope
 ) {
     private val screenOffReceiver = ScreenOffReceiver()
@@ -49,6 +51,7 @@ class ScriptRunnerServiceController @Inject constructor(
         imageLoader.clearImageCache()
 
         overlay.hide()
+        ocrService.close()
         scope.cancel()
 
         screenOffReceiver.unregister(service)

--- a/libautomata/src/main/java/io/github/lib_automata/OcrService.kt
+++ b/libautomata/src/main/java/io/github/lib_automata/OcrService.kt
@@ -2,4 +2,6 @@ package io.github.lib_automata
 
 interface OcrService {
     fun detectText(pattern: Pattern): String
+
+    fun close()
 }

--- a/libautomata/src/main/java/io/github/lib_automata/OcrService.kt
+++ b/libautomata/src/main/java/io/github/lib_automata/OcrService.kt
@@ -3,5 +3,12 @@ package io.github.lib_automata
 interface OcrService {
     fun detectText(pattern: Pattern): String
 
+    /**
+     * Cleans up resources used by the OCR service.
+     *
+     * This method should be called when the OCR service is no longer needed
+     * to release any resources (e.g., memory, file handles, or other system resources)
+     * that may have been allocated during its operation.
+     */
     fun close()
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Chore
- [ ] Bugfix
- [X] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
- Make the Tesseract load once per service
- ensure tesseract proper closing of resources
- Implement SHA-256 validation to verify file integrity during asset copying, while streamlining the copying process.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Additional context
<!-- Add any other context about the pull request here. -->
This pull request refactors the `TesseractOcrService` and its integration into the project, improving resource management, error handling, and modularity. The changes also update the dependency injection setup and ensure proper cleanup of OCR-related resources.

### Dependency Injection Updates:
* Removed the binding of `TesseractOcrService` as `OcrService` from `ScriptsModule` and added it to `ServiceModule` to scope it appropriately to services. (`ScriptsModule.kt`: [[1]](diffhunk://#diff-bd24b4a6e901a3557f3873949f3bf500c1a1162052837e65c24a9455c5141d71L8) [[2]](diffhunk://#diff-bd24b4a6e901a3557f3873949f3bf500c1a1162052837e65c24a9455c5141d71L18) [[3]](diffhunk://#diff-bd24b4a6e901a3557f3873949f3bf500c1a1162052837e65c24a9455c5141d71L50-L53); `ServiceModule.kt`: [[4]](diffhunk://#diff-411506b2c1149b9642d90acc5b3431e2ac225192024eb9e98a4cff5b8ab23659R8-R12) [[5]](diffhunk://#diff-411506b2c1149b9642d90acc5b3431e2ac225192024eb9e98a4cff5b8ab23659R25-R28)

### `TesseractOcrService` Enhancements:
* Changed the scope of `TesseractOcrService` from `ScriptScope` to `ServiceScoped` and implemented the `AutoCloseable` interface for better resource management. (`TesseractOcrService.kt`: [app/src/main/java/io/github/fate_grand_automata/imaging/TesseractOcrService.ktL4-R22](diffhunk://#diff-c6a30690e1c7a89bf2928505b33648fab849625b7c707ab9f9cb3e0580689db7L4-R22))
* Added hash-based validation for Tesseract training data files to ensure data integrity and avoid unnecessary file overwrites. (`TesseractOcrService.kt`: [[1]](diffhunk://#diff-c6a30690e1c7a89bf2928505b33648fab849625b7c707ab9f9cb3e0580689db7L39-R88) [[2]](diffhunk://#diff-c6a30690e1c7a89bf2928505b33648fab849625b7c707ab9f9cb3e0580689db7L71-R149)
* Replaced `finalize` with an explicit `close` method for predictable cleanup of the Tesseract API and improved logging using `Timber`. (`TesseractOcrService.kt`: [app/src/main/java/io/github/fate_grand_automata/imaging/TesseractOcrService.ktL71-R149](diffhunk://#diff-c6a30690e1c7a89bf2928505b33648fab849625b7c707ab9f9cb3e0580689db7L71-R149))

### Integration with `ScriptRunnerServiceController`:
* Injected `OcrService` into `ScriptRunnerServiceController` and ensured it is properly closed during cleanup to release resources. (`ScriptRunnerServiceController.kt`: [[1]](diffhunk://#diff-75bbb4b08199a1b4c706bdb4f54b7fd7386fd0bdc9e33dabbb3315248fc96f24R17) [[2]](diffhunk://#diff-75bbb4b08199a1b4c706bdb4f54b7fd7386fd0bdc9e33dabbb3315248fc96f24R40) [[3]](diffhunk://#diff-75bbb4b08199a1b4c706bdb4f54b7fd7386fd0bdc9e33dabbb3315248fc96f24R54)

### `OcrService` Interface Update:
* Added a `close` method to the `OcrService` interface to standardize resource cleanup across implementations. (`OcrService.kt`: [libautomata/src/main/java/io/github/lib_automata/OcrService.ktR5-R13](diffhunk://#diff-73b66ef21be04126cf7d6353cab71ffa859d821f48afb496e6ce936908c21952R5-R13))