### PR TITLE
fix consumption of find all images twice

### DIFF
--- a/libautomata/src/main/java/io/github/lib_automata/ImageMatcher.kt
+++ b/libautomata/src/main/java/io/github/lib_automata/ImageMatcher.kt
@@ -46,7 +46,7 @@ interface ImageMatcher {
         region: Region,
         pattern: Pattern,
         similarity: Double? = null
-    ): Sequence<Match>
+    ): List<Match>
 
     fun isWhite(region: Region): Boolean
     fun isBlack(region: Region): Boolean
@@ -144,8 +144,8 @@ class RealImageMatcher @Inject constructor(
         )
     }
 
-    override fun findAll(region: Region, pattern: Pattern, similarity: Double?) =
-        screenshotManager.getScreenshot()
+    override fun findAll(region: Region, pattern: Pattern, similarity: Double?): List<Match> {
+        val matches = screenshotManager.getScreenshot()
             .crop(transform.toImage(region))
             .findMatches(
                 pattern,
@@ -159,12 +159,15 @@ class RealImageMatcher @Inject constructor(
 
                 Match(matchedRegion, it.score)
             }
-            .also {
-                highlight(
-                    region,
-                    color = if (it.any()) HighlightColor.Success else HighlightColor.Error
-                )
-            }
+            .toList() // Convert to list to avoid sequence consumption issues
+        
+        highlight(
+            region,
+            color = if (matches.any()) HighlightColor.Success else HighlightColor.Error
+        )
+        
+        return matches
+    }
 
     override fun isWhite(region: Region) =
         screenshotManager.getScreenshot()


### PR DESCRIPTION
This pull request updates the `findAll` method in the `ImageMatcher` interface and its implementation to improve reliability and consistency by changing the return type from `Sequence<Match>` to `List<Match>`. This change ensures that match results are fully realized and avoids potential issues with sequence consumption and side effects.

**Interface and implementation changes:**

* Changed the return type of `findAll` in the `ImageMatcher` interface from `Sequence<Match>` to `List<Match>` for more predictable and safer usage.
* Updated the `findAll` implementation in `RealImageMatcher` to collect matches into a list before returning, preventing issues related to consuming sequences multiple times. [[1]](diffhunk://#diff-bcacdb6c8bf30ae17217371cb51709a41e5075bdbc03e2b2c5b26f370ee42507L147-R148) [[2]](diffhunk://#diff-bcacdb6c8bf30ae17217371cb51709a41e5075bdbc03e2b2c5b26f370ee42507L162-R169)