### PR TITLE
feat: update SupportBounds from data class to value class

### DIFF
--- a/scripts/src/main/java/io/github/fate_grand_automata/scripts/supportSelection/SupportBoundsFinder.kt
+++ b/scripts/src/main/java/io/github/fate_grand_automata/scripts/supportSelection/SupportBoundsFinder.kt
@@ -7,7 +7,8 @@ import io.github.lib_automata.Region
 import io.github.lib_automata.dagger.ScriptScope
 import javax.inject.Inject
 
-data class SupportBounds(val region: Region)
+@JvmInline
+value class SupportBounds(val region: Region)
 
 @ScriptScope
 class SupportBoundsFinder @Inject constructor(


### PR DESCRIPTION
This pull request makes a small change to the `SupportBounds` class to improve efficiency and interoperability with Java. Specifically, it converts `SupportBounds` from a regular data class to a Kotlin value class using `@JvmInline`, which can reduce memory overhead and improve performance when the class is used as a wrapper.

* Converted `SupportBounds` from a data class to a Kotlin value class with `@JvmInline` for better performance and Java interoperability.