### PR TITLE
Downgrade OpenCV to fix crashes

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ google_android_play_version = "2.1.0"
 activity_version = "1.10.1"
 mockk_version = "1.14.5"
 
-opencv_version = "4.12.0"
+opencv_version = "4.11.0"
 navigation_compose_version = "2.9.3"
 
 recyclerview_version = "1.4.0"


### PR DESCRIPTION
User on Discord reported a crash on Bluestacks when matching images and there is also another new crash in the Play Console when converting screenshots to RBG, mostly on Android 15 devices.