### PR TITLE
fix: add blank localized-en for the en localized fallback for android 14 and above

### DIFF
--- a/app/src/main/res/values-en/localized.xml
+++ b/app/src/main/res/values-en/localized.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- This file is intentionally blank to ensure English devices use default resources from `res/values/` and don't fall back to other translations. -->
+</resources>


### PR DESCRIPTION
# New Pull Request
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

<!-- Please select what type of pull request this is: [x] -->
- [ ] Chore/Refactor
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
- #2007
- #2006

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Added blank localized to ensure that "EN" would be recognized by some devices.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Additional context
<!-- Add any other context about the pull request here. -->

This pull request introduces an empty `localized.xml` file for the English locale. This ensures that devices set to English use the default resources and do not fall back to other translations.

- Localization handling:
  * Added an intentionally blank `app/src/main/res/values-en/localized.xml` file to force English devices to use default resources and prevent fallback to other translations.