### PR TITLE
feat: throw error when support images not found

### DIFF
--- a/app/src/main/java/io/github/fate_grand_automata/util/ImageLoader.kt
+++ b/app/src/main/java/io/github/fate_grand_automata/util/ImageLoader.kt
@@ -94,6 +94,9 @@ class ImageLoader @Inject constructor(
 
     private fun fileLoader(kind: SupportImageKind, name: String): List<Pattern> {
         val inputStreams = storageProvider.readSupportImage(kind, name)
+        if (inputStreams.isEmpty()) {
+            throw SupportImageNotFoundException(kind, name)
+        }
         return inputStreams.withIndex().map { (i, stream) ->
             stream.use {
                 DroidCvPattern(it, colorManager.isColor, "$name:$i")
@@ -115,6 +118,9 @@ class ImageLoader @Inject constructor(
             )
         }
 }
+
+class SupportImageNotFoundException(kind: SupportImageKind, name: String) : 
+    Exception("Support image not found for kind: $kind, name: $name")
 
 val MaterialEnum.drawable
     get() = when (this) {


### PR DESCRIPTION
# New Pull Request
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

<!-- Please select what type of pull request this is: [x] -->
- [ ] Chore/Refactor
- [ ] Bugfix
- [X] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
We should throw an error when the support template images are empty(i.e. possibly problem with storage permissions hence unable to get all of the support template images)

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Additional context
<!-- Add any other context about the pull request here. -->