### PR TITLE
ci: revert pull_request_target and constraint PR comment to only in-repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,16 +90,27 @@ jobs:
       - name: zip APK
         run: zip FGA-apk-${VERSION_CODE}.zip *.apk
       
-      - name: Create release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create tag
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b
         with:
-          tag_name: v${{ env.VERSION_CODE }}
-          name: FGA ${{ env.VERSION_CODE }}
+          custom_tag: ${{ env.VERSION_CODE }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create release
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd
+        id: github-release
+        with:
+          generateReleaseNotes: true
+          artifacts: 'FGA-apk-${{ env.VERSION_CODE }}.zip'
+          tag: 'v${{ env.VERSION_CODE }}'
+          name: 'FGA ${{ env.VERSION_CODE }}'
+
+      - name: Add installation instructions to release
+        uses: irongut/EditRelease@ccf529ad26dddf9996e7dd0f24ca5da4ea507cc2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          id: ${{ steps.github-release.outputs.id }}
+          replacebody: false
           body: |
             > [!NOTE] 
             > Use the [APKMirror Installer](https://play.google.com/store/apps/details?id=com.apkmirror.helper.prod) to install the app on Android 14+, otherwise Accessibility can't be enabled.
-          files: |
-            FGA-apk-${{ env.VERSION_CODE }}.zip
-          generate_release_notes: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-ci
   cancel-in-progress: true
 
 env:
@@ -89,27 +89,17 @@ jobs:
           SUPPLY_JSON_KEY_DATA: ${{ secrets.SERVICE_ACCOUNT_NEW_APP }}
       - name: zip APK
         run: zip FGA-apk-${VERSION_CODE}.zip *.apk
-      - name: Create tag
-        uses: mathieudutour/github-tag-action@va22cf08638b34d5badda920f9daf6e72c477b07b
-        with:
-          custom_tag: ${{ env.VERSION_CODE }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
+      
       - name: Create release
-        uses: ncipollo/release-action@v339a81892b84b4eeb0f6e744e4574d79d0d9b8dd
-        id: github-release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          generateReleaseNotes: true
-          artifacts: 'FGA-apk-${{ env.VERSION_CODE }}.zip'
-          tag: 'v${{ env.VERSION_CODE }}'
-          name: 'FGA ${{ env.VERSION_CODE }}'
-
-      - name: Add installation instructions to release
-        uses: irongut/EditRelease@v1.2.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          id: ${{ steps.github-release.outputs.id }}
-          replacebody: false
+          tag_name: v${{ env.VERSION_CODE }}
+          name: FGA ${{ env.VERSION_CODE }}
           body: |
             > [!NOTE] 
             > Use the [APKMirror Installer](https://play.google.com/store/apps/details?id=com.apkmirror.helper.prod) to install the app on Android 14+, otherwise Accessibility can't be enabled.
+          files: |
+            FGA-apk-${{ env.VERSION_CODE }}.zip
+          generate_release_notes: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRO }}
@@ -52,13 +53,13 @@ jobs:
         working-directory: ./app
         run: gpg --quiet --batch --yes --decrypt --passphrase="$GPG_KEYSTORE" --output fgautomata.keystore fgautomata.keystore.gpg
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f
         with:
           ruby-version: '4.0.2'
           bundler-cache: true
 
       - name: Deploy to Play Store
-        uses: maierj/fastlane-action@v3.1.0
+        uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7
         with:
           lane: 'deploy'
         env:
@@ -66,21 +67,21 @@ jobs:
           KEYSTORE_PASS: ${{ secrets.KEYSTORE_PASS }}
 
       - name: Upload Bundle
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: bundle
           path: app/build/outputs/bundle/release/app-release.aab
         if: ${{ !cancelled() }}
 
       - name: Upload De-obfuscation mapping file
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: mapping-release
           path: app/build/outputs/mapping/release/mapping.txt
         if: ${{ !cancelled() }}
 
       - name: Download Universal APK
-        uses: maierj/fastlane-action@v3.1.0
+        uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7
         with:
           lane: 'download_apk'
           options: '{ "version_code": "$VERSION_CODE" }'
@@ -89,13 +90,13 @@ jobs:
       - name: zip APK
         run: zip FGA-apk-${VERSION_CODE}.zip *.apk
       - name: Create tag
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@va22cf08638b34d5badda920f9daf6e72c477b07b
         with:
           custom_tag: ${{ env.VERSION_CODE }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create release
-        uses: ncipollo/release-action@v1.21.0
+        uses: ncipollo/release-action@v339a81892b84b4eeb0f6e744e4574d79d0d9b8dd
         id: github-release
         with:
           generateReleaseNotes: true

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close Issue
-        uses: peter-evans/close-issue@v3
+        uses: peter-evans/close-issue@05dff7ca07116e5707cfb3a3cd4af7bb5e43524c
         with:
           comment: |
             It seems like you have not used one of the issue templates when creating this issue.
@@ -19,11 +19,11 @@ jobs:
             
             This action was performed automatically.
       - name: Lock Issue
-        uses: OSDKDev/lock-issues@v1.2
+        uses: OSDKDev/lock-issues@bc750a3e24b4ee73f3d4c445957dadf019e428de
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Label Issue
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@bd52874380e3909a1ac983768df6976535ece7f8
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: insufficient info

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -7,7 +7,7 @@ jobs:
     if: >-
           github.event.issue.user.id != 10654537 && github.event.issue.user.id != 12360257 &&
           join(github.event.issue.labels) == ''
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Close Issue
         uses: peter-evans/close-issue@05dff7ca07116e5707cfb3a3cd4af7bb5e43524c

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,7 +1,7 @@
 name: PR Build
 
 on:
-  pull_request_target:
+  pull_request:
     paths-ignore:
       - '.idea/**'
       - '.github/ISSUE_TEMPLATE/**'
@@ -92,7 +92,11 @@ jobs:
           path: ${{ env.FGA_MAPPING_PATH }}
       
       - name: Comment the APK
-        if: ${{ github.event_name != 'workflow_dispatch' && github.actor != 'renovate[bot]' }}
+        if: ${{ 
+            github.event_name != 'workflow_dispatch' &&
+            github.actor != 'renovate[bot]' &&
+            github.repository == 'Fate-Grand-Automata/FGA'
+          }}
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b
         with:
           comment-tag: apk

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -29,7 +29,7 @@ jobs:
       pull-requests: write 
     steps:
       # get the PR from the event as JSON
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         id: pr
         with:
           script: |
@@ -40,12 +40,12 @@ jobs:
             return pullRequest
       
       # check out the merged result
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{fromJSON(steps.pr.outputs.result).merge_commit_sha}}
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRO }}
@@ -80,20 +80,20 @@ jobs:
 
       - name: Upload APK
         id: upload-apk
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ env.FGA_APK_ARTIFACT_NAME }}
           path: ${{ env.FGA_APK_PATH }}
 
       - name: Upload De-obfuscation mapping file
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ env.FGA_MAPPING_ARTIFACT_NAME }}
           path: ${{ env.FGA_MAPPING_PATH }}
       
       - name: Comment the APK
         if: ${{ github.event_name != 'workflow_dispatch' && github.actor != 'renovate[bot]' }}
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b
         with:
           comment-tag: apk
           message: |

--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -18,5 +18,6 @@ jobs:
   publish-wiki:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: Andrew-Chen-Wang/github-wiki-action@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - uses: Andrew-Chen-Wang/github-wiki-action@64efa0a9436db17670a2259e0ac249d6f08bb352


### PR DESCRIPTION
- reverts fc9fd2be0e032a6d678b87172ddd0133ac262865 to only use pull_request and add constraint to only comment when in-repo
- Stacked with #2214

https://www.paloaltonetworks.com/blog/cloud-security/trivy-supply-chain-attack/