### PR TITLE
fix(servant): adjust ember confirmation dialog region for non-JP servers

### DIFF
--- a/scripts/src/main/java/io/github/fate_grand_automata/scripts/locations/ServantLevelLocations.kt
+++ b/scripts/src/main/java/io/github/fate_grand_automata/scripts/locations/ServantLevelLocations.kt
@@ -11,7 +11,7 @@ class ServantLevelLocations @Inject constructor(
 
     val emberConfirmationDialogRegion = when (gameServer) {
         is GameServer.Jp -> Region(321, 1209, 160, 100).xFromCenter()
-        else -> Region(341, 1229, 120, 60).xFromCenter()
+        else -> Region(338, 1229, 130, 70).xFromCenter()
     }
 
     val emberConfirmationDialogLocation = when (isWide) {


### PR DESCRIPTION
close 2238 
Only verified on CN server. TW/KR/EN servers share the same region parameters but have not been tested individually. Feedback from users on other servers is welcome.