### PR TITLE
Fixes bug where there is no valid CE found when there is a valid CE present

### DIFF
--- a/scripts/src/main/java/io/github/fate_grand_automata/scripts/entrypoints/AutoCEBomb.kt
+++ b/scripts/src/main/java/io/github/fate_grand_automata/scripts/entrypoints/AutoCEBomb.kt
@@ -52,6 +52,10 @@ class AutoCEBomb @Inject constructor(
     class ExitException(val reason: ExitReason) : Exception()
 
     private fun findBaseCE(): Match {
+        // Scroll to top
+        Location(2040, 400).click()
+        2.seconds.wait()
+        
         for (img in imagesForSelectedRarity()) {
             val matches = locations.levelOneCERegion
                 .findAll(images[img])


### PR DESCRIPTION
# Summary
This bug occurs because we don't scroll to the top before trying to find a base CE. Here's what currently happens:

1. Script clicks on "CE to enhance"
2. Since the CEs are sorted by level, level 1 CEs are present at the top
3. We then select the CEs to use for enhancing and enhance the base CE
4. We click CE Enhance again
5. We search for another level 1 base CE WITHOUT SCROLLING TO THE TOP

Here's the problem: If we don't scroll to the top, the UI automatically centers around the original enhanced CE. Since the original enhanced CE is now around level 10 - 15, the UI centers around the bottom. Thus, as CEs build up, there is a chance that no level 1 CEs are found because the UI gets crowded by the already enhanced CEs

For example, in this image, the base CE "Barrier" is enhanced to level 15.
<img width="1923" height="1080" alt="image" src="https://github.com/user-attachments/assets/46469806-2690-4e30-a315-ee00233274af" />

As you can see, when it comes time to choose the next base CE, the script wouldn't be able to find it. However, if we were to scroll to the top, we will be able to find some valid CEs to use. 

<img width="1923" height="1080" alt="image" src="https://github.com/user-attachments/assets/bf6ce724-8838-4da7-8eb8-a7f9c6cb33b1" />

