### PR TITLE
Update Agents.md

### DIFF
--- a/.claude/rules/assets-and-i18n.md
+++ b/.claude/rules/assets-and-i18n.md
@@ -1,9 +1,0 @@
----
-paths: "app/src/main/assets/**,app/src/main/res/**"
-description: Per-server template image folders, the En fallback, and the external POEditor translation flow.
----
-
-Template images are per-server with an `En` fallback and must be 720p. English strings live in
-`values/localized.xml` and are edited here; the translated `values-*` copies come from POEditor.
-
-Read [`docs/agents/assets-and-i18n.md`](../../docs/agents/assets-and-i18n.md).

--- a/.claude/rules/servers-and-assets.md
+++ b/.claude/rules/servers-and-assets.md
@@ -1,0 +1,8 @@
+---
+paths: "app/src/main/assets/**"
+description: Per-server template image folders and the En fallback.
+---
+
+Template images are per-server with an `En` fallback and must be 720p.
+
+Read [`docs/agents/servers-and-assets.md`](../../docs/agents/servers-and-assets.md).

--- a/.claude/rules/translations.md
+++ b/.claude/rules/translations.md
@@ -1,0 +1,9 @@
+---
+paths: "app/src/main/res/**"
+description: The English string source and the external POEditor translation flow.
+---
+
+English strings live in `values/localized.xml` and are edited here; the translated
+`values-*` copies come from POEditor.
+
+Read [`docs/agents/translations.md`](../../docs/agents/translations.md).

--- a/.github/instructions/assets-and-i18n.instructions.md
+++ b/.github/instructions/assets-and-i18n.instructions.md
@@ -1,9 +1,0 @@
----
-applyTo: "app/src/main/assets/**,app/src/main/res/**"
-description: Per-server template image folders, the En fallback, and the external POEditor translation flow.
----
-
-Template images are per-server with an `En` fallback and must be 720p. English strings live in
-`values/localized.xml` and are edited here; the translated `values-*` copies come from POEditor.
-
-Read [`docs/agents/assets-and-i18n.md`](../../docs/agents/assets-and-i18n.md).

--- a/.github/instructions/servers-and-assets.instructions.md
+++ b/.github/instructions/servers-and-assets.instructions.md
@@ -1,0 +1,8 @@
+---
+applyTo: "app/src/main/assets/**"
+description: Per-server template image folders and the En fallback.
+---
+
+Template images are per-server with an `En` fallback and must be 720p.
+
+Read [`docs/agents/servers-and-assets.md`](../../docs/agents/servers-and-assets.md).

--- a/.github/instructions/translations.instructions.md
+++ b/.github/instructions/translations.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "app/src/main/res/**"
+description: The English string source and the external POEditor translation flow.
+---
+
+English strings live in `values/localized.xml` and are edited here; the translated
+`values-*` copies come from POEditor.
+
+Read [`docs/agents/translations.md`](../../docs/agents/translations.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,5 @@
 # AGENTS.md
 
-Guidance for AI coding agents working in this repository. It follows the [AGENTS.md](https://agents.md/) convention, so any agent that supports it picks this file up directly; `CLAUDE.md` just includes it.
-
 Path-specific guidance lives in [`docs/agents/`](docs/agents/) so it is loaded only when relevant: read a guide when its trigger below matches. Copilot and Claude Code pick the same guides up automatically via stubs in `.github/instructions/` and `.claude/rules/` — see [`docs/agents/README.md`](docs/agents/README.md).
 
 ## What this is
@@ -18,8 +16,7 @@ Fate/Grand Automata (FGA) — an Android app that automates farming in the game 
 ## Build & test
 
 ```bash
-./gradlew assembleDebug          # debug APK, applicationId suffix .test, signed with committed app/fgadebug.keystore
-./gradlew assembleCi             # minified release-like APK signed with the debug keystore (what PR CI builds)
+./gradlew :app:compileDebugKotlin # Compiles the kotlin code for the android app.
 ./gradlew :scripts:test          # the only unit tests in the repo (JUnit 5 + assertk + mockk)
 ./gradlew :scripts:test --tests '*SupportSelectionTest'          # single test class
 ./gradlew :scripts:test --tests '*SupportSelectionTest.someName' # single test method
@@ -29,8 +26,6 @@ Fate/Grand Automata (FGA) — an Android app that automates farming in the game 
 
 - Everything builds on **JDK 21** via a Gradle toolchain pin; emitted bytecode stays at **Java 11**.
 - `lint` reports `MissingTranslation` **errors** on `app`. That is the expected steady state, not a regression — don't try to fix them in-repo.
-- `versionCode`/`versionName` come from the `FGA_VERSION_CODE`/`FGA_VERSION_NAME` env vars (default 1 / "0.1.0"). When installing a debug build over a store install, set `FGA_VERSION_CODE` to at least the installed version — Android refuses downgrades.
-- `release` builds need `app/fgautomata.keystore` and `KEYSTORE_PASS` and are CI-only; deploys go through `fastlane`.
 
 ## Module layout and dependency direction
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ Fate/Grand Automata (FGA) — an Android app that automates farming in the game 
 - **Any on-screen coordinate, any file in `scripts/.../locations/`, any template image added to `app/src/main/assets/`** — [`docs/agents/coordinates.md`](docs/agents/coordinates.md). Matching runs at 720p, coordinates are 1440p, and the X origin depends on aspect ratio.
 - **`gradle/libs.versions.toml`, the Gradle wrapper, any `build.gradle.kts`** — [`docs/agents/dependencies.md`](docs/agents/dependencies.md). The AGP/Gradle/Kotlin/androidx bumps only succeed in one order; it also holds the JDK, bytecode-target and `compileSdk` pins.
 - **Automation logic in `scripts/`, or the Hilt wiring in `app/di/` and `app/runner/`** — [`docs/agents/automation-scripts.md`](docs/agents/automation-scripts.md). Every run gets its own Hilt component, and `script()` never returns normally.
-- **Assets or strings under `app/src/main/res/`** — [`docs/agents/assets-and-i18n.md`](docs/agents/assets-and-i18n.md). English strings live in `values/localized.xml`; the translated `values-*` copies are synced from POEditor.
+- **Any file in `app/src/main/assets/`** — [`docs/agents/servers-and-assets.md`](docs/agents/servers-and-assets.md). Template images are per-server with an `En` fallback; server choice and app language are independent.
+- **Strings under `app/src/main/res/`** — [`docs/agents/translations.md`](docs/agents/translations.md). English strings live in `values/localized.xml`; the translated `values-*` copies are synced from POEditor.
 
 ## Build & test
 

--- a/docs/agents/servers-and-assets.md
+++ b/docs/agents/servers-and-assets.md
@@ -1,0 +1,12 @@
+# Game servers and assets
+
+`app/src/main/assets/{En,Jp,Cn,Tw,Kr}/` hold per-server template images, named by `Images`
+enum entries (`scripts/.../Images.kt`). `ImageLoader` looks up the current server's folder
+and **falls back to `En`** when the file is absent, so only add a server-specific copy when
+the art actually differs. `IFgoAutomataApi.findImage` additionally tries the `En` image on
+JP to support TranslateFGO. `assets/Support/` holds user-provided servant/CE images;
+`assets/tessdata/` the OCR data. Template images must be 720p — see the coordinates guide.
+
+Server choice and app language are independent: a user can run the JP server with the app's
+UI in English, or the EN server in Korean. Don't assume they're coupled when reading prefs or
+adding server-specific behavior.

--- a/docs/agents/translations.md
+++ b/docs/agents/translations.md
@@ -1,11 +1,4 @@
-# Game servers, assets and localization
-
-`app/src/main/assets/{En,Jp,Cn,Tw,Kr}/` hold per-server template images, named by `Images`
-enum entries (`scripts/.../Images.kt`). `ImageLoader` looks up the current server's folder
-and **falls back to `En`** when the file is absent, so only add a server-specific copy when
-the art actually differs. `IFgoAutomataApi.findImage` additionally tries the `En` image on
-JP to support TranslateFGO. `assets/Support/` holds user-provided servant/CE images;
-`assets/tessdata/` the OCR data. Template images must be 720p — see the coordinates guide.
+# Localization
 
 `app/src/main/res/values/localized.xml` holds the English source of every translatable
 string — add and edit them there, in the source tree. `values/strings.xml` is only for


### PR DESCRIPTION
- Remove redundant info

```diff
- Guidance for AI coding agents working in this repository. It follows the [AGENTS.md](https://agents.md/) convention, so any agent that supports it picks this file up directly; `CLAUDE.md` just includes it.
```

- Use the `./gradlew :app:compileDebugKotlin` for much faster checking compared to assembling the apk

- Unless going to automate the creation of apk, might as well remove this

```diff
- `versionCode`/`versionName` come from the `FGA_VERSION_CODE`/`FGA_VERSION_NAME` env vars (default 1 / "0.1.0"). When installing a debug build over a store install, set `FGA_VERSION_CODE` to at least the installed version — Android refuses downgrades.
- `release` builds need `app/fgautomata.keystore` and `KEYSTORE_PASS` and are CI-only; deploys go through `fastlane`.
```