### PR TITLE
Add a workaround for OpenCV crashing on Bluestacks Air (macOS)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import javax.inject.Inject
+
 plugins {
     alias(libs.plugins.android.application)
     id("kotlin-parcelize")
@@ -5,6 +7,73 @@ plugins {
     alias(libs.plugins.ksp)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.kotlin.serialization)
+}
+
+/*
+ * OpenCV is pinned to 4.11.0 because every later release bundles a KleidiCV that runs
+ * SVE instructions, and BlueStacks Air on macOS advertises SVE2 in HWCAP2 without
+ * implementing SVE, so those builds die with SIGILL. Do not bump `opencv_version`
+ * until that is fixed upstream.
+ *
+ * The 4.11.0 AAR ships a 4 KB aligned libc++_shared.so, which Play's 16 KB page size
+ * requirement rejects, so the 16 KB aligned copy from a current OpenCV release is
+ * packaged in its place. libc++_shared.so only ever gains symbols, so the newer one
+ * still satisfies the older libopencv_java4.so.
+ */
+val alignedLibCxx = configurations.create("alignedLibCxx") {
+    isTransitive = false
+}
+
+abstract class ExtractAlignedLibCxx : DefaultTask() {
+    @get:InputFiles
+    abstract val aar: ConfigurableFileCollection
+
+    @get:OutputDirectory
+    abstract val outputDir: DirectoryProperty
+
+    @get:Inject
+    abstract val archives: ArchiveOperations
+
+    @get:Inject
+    abstract val files: FileSystemOperations
+
+    @TaskAction
+    fun extract() {
+        files.sync {
+            from(archives.zipTree(aar.singleFile)) {
+                include("jni/*/libc++_shared.so")
+                // jniLibs source dirs are laid out as <abi>/<lib>, the AAR as jni/<abi>/<lib>.
+                eachFile { path = path.removePrefix("jni/") }
+            }
+            includeEmptyDirs = false
+            into(outputDir)
+        }
+
+        /*
+         * On an empty extraction the packaging step falls back to OpenCV's own 4 KB aligned
+         * copy and the build still succeeds, so Play would be the first thing to complain.
+         */
+        if (!outputDir.get().file("arm64-v8a/libc++_shared.so").asFile.exists()) {
+            throw GradleException(
+                "No arm64-v8a/libc++_shared.so in ${aar.singleFile.name} — its layout changed.",
+            )
+        }
+    }
+}
+
+val extractAlignedLibCxx = tasks.register<ExtractAlignedLibCxx>("extractAlignedLibCxx") {
+    description = "Extracts the 16 KB aligned libc++_shared.so packaged in place of OpenCV's."
+    aar.from(alignedLibCxx)
+    outputDir.set(layout.buildDirectory.dir("alignedLibCxx"))
+}
+
+androidComponents {
+    onVariants { variant ->
+        variant.sources.jniLibs?.addGeneratedSourceDirectory(
+            extractAlignedLibCxx,
+            ExtractAlignedLibCxx::outputDir,
+        )
+    }
 }
 
 android {
@@ -79,6 +148,13 @@ android {
     // run tests in CI builds instad of debug
     testBuildType = "ci"
 
+    packaging {
+        jniLibs {
+            // Project-local jniLibs are merged ahead of any dependency's, so ours wins.
+            pickFirsts += "**/libc++_shared.so"
+        }
+    }
+
     namespace = "io.github.fate_grand_automata"
 }
 
@@ -109,6 +185,7 @@ dependencies {
     implementation(libs.androidx.constraintlayout)
 
     implementation(libs.opencv)
+    alignedLibCxx("${libs.opencv.aligned.libcxx.get()}@aar")
     implementation(libs.tesseract4android)
 
     implementation(libs.lifecycle.viewmodel.ktx)

--- a/docs/agents/dependencies.md
+++ b/docs/agents/dependencies.md
@@ -21,6 +21,20 @@
 - `compileSdk` is **37** while `targetSdk` stays **36** — recent androidx libraries force
   the compile level, but nothing opts into new runtime behavior. Keep the two decoupled;
   bumping `targetSdk` is a separate, user-visible decision.
+- **OpenCV is pinned to 4.11.0** and Renovate is told to leave it alone. Every release bundles
+  ARM's KleidiCV; 4.11.0's (0.3.0) never calls its SVE kernels, 4.12.0's and later do. BlueStacks
+  Air on macOS advertises `HWCAP2_SVE2` without implementing SVE, so those later builds die with
+  `SIGILL` — at first image match on 4.12/4.13, and at `System.loadLibrary` on 4.14, where a
+  static constructor probes the vector length with `rdvl`. Vetting a bump means checking whether
+  an SVE instruction is *reachable*, not whether one is present: 4.11.0 contains `rdvl` too, just
+  with nothing calling it. `strings libopencv_java4.so | grep 'Custom HAL'` only reports the
+  KleidiCV version, of which 0.3.0 is the known-good one — and note that stock `objdump` cannot
+  disassemble these files (`architecture UNKNOWN`), so a grep over its output silently finds
+  nothing for every version.
+- The 4.11.0 AAR's `libc++_shared.so` is 4 KB aligned while Play requires 16 KB, so
+  `app/build.gradle.kts` extracts the 16 KB aligned copy from a separately pinned
+  `opencv_aligned_libcxx_version` and packages that instead. Bump it by hand: both catalog entries
+  are the same Maven coordinate, so the Renovate rule that pins `opencv_version` silences it too.
 - Build types: `debug`, `release`, and `ci` (`initWith(release)`, debug-signed, ARM-only
   ABIs). The `ci` type must exist in every Android module (`app`, `prefs`).
 - CI's Gradle cache comes from `gradle/actions/setup-gradle`, not `setup-java`'s

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,9 @@ google_android_play_version = "2.1.0"
 activity_version = "1.13.0"
 mockk_version = "1.14.11"
 
-opencv_version = "4.14.0"
+opencv_version = "4.11.0"
+# Only used for its 16 KB aligned libc++_shared.so, see app/build.gradle.kts
+opencv_aligned_libcxx_version = "4.14.0"
 nav3_core_version = "1.1.7"
 
 reorderable_version = "3.1.0"
@@ -89,6 +91,7 @@ androidx-documentfile = { module = "androidx.documentfile:documentfile", version
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout_version" }
 
 opencv = { group = "org.opencv", name = "opencv", version.ref = "opencv_version" }
+opencv-aligned-libcxx = { group = "org.opencv", name = "opencv", version.ref = "opencv_aligned_libcxx_version" }
 tesseract4android = { module = "cz.adaptech.tesseract4android:tesseract4android", version.ref = "tesseract4android_version" }
 
 junit-bom = { group = "org.junit", name = "junit-bom", version.ref = "junit_bom_version" }

--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,11 @@
   },
   "packageRules": [
     {
+      "description": "OpenCV 4.12.0+ calls KleidiCV SVE kernels, which SIGILL on BlueStacks Air (macOS). This also suppresses opencv_aligned_libcxx_version, the same coordinate, which must be bumped by hand. See app/build.gradle.kts.",
+      "matchPackageNames": ["org.opencv:opencv"],
+      "enabled": false
+    },
+    {
       "groupName": "kotlin",
       "matchPackageNames": [
         "/^org.jetbrains.kotlin/",


### PR DESCRIPTION
Reported the issue to KleidiCV maintainers who can evaluate the problem better than me: https://gitlab.arm.com/kleidi/kleidicv/-/work_items/16

Fixes #2267